### PR TITLE
Integrate full HealthKit v14 export — new domains + aggregate ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # 📈 Activity Trends
 
 A personal dashboard that visualises my Apple Health & Apple Watch data — workouts,
-activity rings, heart & vitals, sleep and body composition.
+activity rings, heart & vitals, sleep, mobility, nutrition, hearing, body
+composition and ECG recordings.
 
 Originally a Create React App frontend backed by a Kotlin/Spring + MongoDB API, it
 was reworked into a **Next.js app on Vercel backed entirely by Supabase**, fed by a
@@ -57,15 +58,25 @@ You'll get `apple_health_export/export.xml` and an `workout-routes/` folder of G
 
 ```bash
 npm run ingest -- \
-  --export ./data/export.xml \
-  --routes ./data/workout-routes \
-  --tz Europe/London
+  --export ./data/apple_health_export/export.xml \
+  --routes ./data/apple_health_export/workout-routes \
+  --ecg ./data/apple_health_export/electrocardiograms
 ```
 
-The script streams the (multi-GB) XML, loads workouts / records / activity summaries,
-links GPX routes to workouts by time, loads sleep (from `data/fallback/sleep.csv` if
-no `--sleep-csv` is given), and rebuilds the `daily_metrics` rollup. It is
-idempotent — it resets the data tables first unless you pass `--no-reset`.
+The script streams the (multi-GB) XML and **aggregates the huge high-frequency
+series (heart rate, energy, steps, distance, gait, audio, nutrition…) into daily
+roll-ups in memory** — so the database stays small and the ingest is fast. Only a
+small set of low-volume series (resting HR, HRV, weight, blood oxygen, etc.) are
+also kept raw in `health_records` for future drill-down. It also:
+
+- builds sleep sessions from native `SleepAnalysis` stages (Core/Deep/REM/Awake),
+  falling back to a Pillow `sleep.csv` only if the export has none;
+- links GPX routes to workouts by time;
+- loads ECG recordings from `electrocardiograms/*.csv` (EN/JA locale aware).
+
+It is idempotent — it resets the data tables first unless you pass `--no-reset`.
+Days are bucketed by the local date embedded in each record, so there's no
+timezone flag to set.
 
 ## Deployment (Vercel)
 

--- a/app/ecg/[id]/page.tsx
+++ b/app/ecg/[id]/page.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { ArrowLeft, HeartPulse } from "lucide-react";
+import { useEcg } from "@/lib/queries/ecg";
+import { PageHeader } from "@/components/dashboard/page-header";
+import { EcgWaveform } from "@/components/charts/ecg-waveform";
+import { ChartSkeleton, ErrorState } from "@/components/dashboard/states";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
+import * as fmt from "@/lib/format";
+
+export default function EcgDetailPage() {
+  const params = useParams<{ id: string }>();
+  const query = useEcg(params.id);
+
+  if (query.isError) return <ErrorState error={query.error} />;
+
+  const ecg = query.data;
+  const samples = (ecg?.samples as number[] | undefined) ?? [];
+  const duration = ecg?.sample_rate_hz ? ecg.sample_count / ecg.sample_rate_hz : null;
+
+  return (
+    <>
+      <Link
+        href="/heart"
+        className="mb-4 inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="h-4 w-4" /> Back to Heart &amp; Vitals
+      </Link>
+
+      {query.isPending || !ecg ? (
+        <div className="space-y-6">
+          <Skeleton className="h-10 w-64" />
+          <ChartSkeleton className="h-[240px]" />
+        </div>
+      ) : (
+        <>
+          <PageHeader
+            title="ECG recording"
+            description={`${fmt.shortDate(ecg.recorded_at)} · ${fmt.timeOfDay(ecg.recorded_at)}`}
+            actions={ecg.classification ? <Badge variant="secondary">{ecg.classification}</Badge> : undefined}
+          />
+
+          <Card className="mb-6">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-base">
+                <HeartPulse className="h-4 w-4 text-chart-4" /> Lead I
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <EcgWaveform samples={samples} />
+              <div className="mt-3 grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">
+                <Meta label="Classification" value={ecg.classification ?? "—"} />
+                <Meta label="Duration" value={duration ? `${duration.toFixed(0)} s` : "—"} />
+                <Meta label="Sample rate" value={ecg.sample_rate_hz ? `${fmt.number(ecg.sample_rate_hz)} Hz` : "—"} />
+                <Meta label="Device" value={ecg.device ?? "—"} />
+              </div>
+              {ecg.symptoms && (
+                <p className="mt-3 text-sm text-muted-foreground">Symptoms: {ecg.symptoms}</p>
+              )}
+            </CardContent>
+          </Card>
+        </>
+      )}
+    </>
+  );
+}
+
+function Meta({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="mt-0.5 font-medium">{value}</p>
+    </div>
+  );
+}

--- a/app/hearing/page.tsx
+++ b/app/hearing/page.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+import { Ear, Headphones, Volume2 } from "lucide-react";
+import { useDailyMetrics } from "@/lib/queries/metrics";
+import { PageHeader } from "@/components/dashboard/page-header";
+import { RangeSelect } from "@/components/dashboard/range-select";
+import { StatCard } from "@/components/dashboard/stat-card";
+import { TrendChart } from "@/components/charts/trend-chart";
+import { CardGridSkeleton, ChartSkeleton, QueryView } from "@/components/dashboard/states";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { RangeKey } from "@/lib/queries/ranges";
+import * as fmt from "@/lib/format";
+import { mean } from "@/lib/stats";
+
+export default function HearingPage() {
+  const [range, setRange] = useState<RangeKey>("90d");
+  const query = useDailyMetrics(range);
+
+  return (
+    <>
+      <PageHeader
+        title="Hearing"
+        description="Environmental and headphone audio exposure levels."
+        actions={<RangeSelect value={range} onChange={setRange} />}
+      />
+
+      <QueryView
+        query={query}
+        loading={
+          <div className="space-y-6">
+            <CardGridSkeleton count={2} />
+            <ChartSkeleton />
+          </div>
+        }
+        isEmpty={(d) => d.every((r) => r.env_audio_db == null && r.headphone_audio_db == null)}
+      >
+        {(m) => (
+          <div className="space-y-6">
+            <div className="grid gap-4 sm:grid-cols-2">
+              <StatCard label="Environmental sound" value={fmt.number(mean(m.map((d) => d.env_audio_db)), 1)} unit="dB" icon={Volume2} accent="text-chart-2" spark={{ data: m, dataKey: "env_audio_db", color: "var(--chart-2)" }} />
+              <StatCard label="Headphone audio" value={fmt.number(mean(m.map((d) => d.headphone_audio_db)), 1)} unit="dB" icon={Headphones} accent="text-chart-3" spark={{ data: m, dataKey: "headphone_audio_db", color: "var(--chart-3)" }} />
+            </div>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Ear className="h-4 w-4 text-chart-2" /> Audio exposure
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <TrendChart
+                  data={m}
+                  series={[
+                    { key: "env_audio_db", label: "Environmental (dB)", type: "line", color: "var(--chart-2)" },
+                    { key: "headphone_audio_db", label: "Headphone (dB)", type: "line", color: "var(--chart-3)" },
+                  ]}
+                  valueFormatter={(v) => `${v.toFixed(0)}`}
+                />
+                <p className="mt-3 text-xs text-muted-foreground">
+                  The WHO suggests keeping sustained exposure below ~70 dB to protect long-term
+                  hearing.
+                </p>
+              </CardContent>
+            </Card>
+          </div>
+        )}
+      </QueryView>
+    </>
+  );
+}

--- a/app/heart/page.tsx
+++ b/app/heart/page.tsx
@@ -1,14 +1,18 @@
 "use client";
 
 import { useState } from "react";
-import { Activity, Droplets, Gauge, HeartPulse, Wind } from "lucide-react";
+import Link from "next/link";
+import { Activity, ChevronRight, Droplets, Gauge, HeartPulse, Wind } from "lucide-react";
 import { useDailyMetrics } from "@/lib/queries/metrics";
+import { useEcgList } from "@/lib/queries/ecg";
 import { PageHeader } from "@/components/dashboard/page-header";
 import { RangeSelect } from "@/components/dashboard/range-select";
 import { StatCard } from "@/components/dashboard/stat-card";
 import { TrendChart } from "@/components/charts/trend-chart";
 import { CardGridSkeleton, ChartSkeleton, QueryView } from "@/components/dashboard/states";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Skeleton } from "@/components/ui/skeleton";
 import type { RangeKey } from "@/lib/queries/ranges";
 import * as fmt from "@/lib/format";
 import { mean, latest, deltaPct } from "@/lib/stats";
@@ -82,6 +86,43 @@ export default function HeartPage() {
           </div>
         )}
       </QueryView>
+
+      <EcgSection />
     </>
+  );
+}
+
+function EcgSection() {
+  const { data, isPending } = useEcgList();
+  if (!isPending && (!data || data.length === 0)) return null;
+
+  return (
+    <Card className="mt-6">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <HeartPulse className="h-4 w-4 text-chart-4" /> ECG recordings
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {isPending
+          ? Array.from({ length: 3 }).map((_, i) => <Skeleton key={i} className="h-12 rounded-lg" />)
+          : data!.map((e) => (
+              <Link
+                key={e.id}
+                href={`/ecg/${e.id}`}
+                className="flex items-center justify-between rounded-lg border px-3 py-2 transition-colors hover:bg-accent/50"
+              >
+                <div>
+                  <p className="text-sm font-medium">{fmt.shortDate(e.recorded_at)}</p>
+                  <p className="text-xs text-muted-foreground">{fmt.timeOfDay(e.recorded_at)}</p>
+                </div>
+                <div className="flex items-center gap-3">
+                  {e.classification && <Badge variant="secondary">{e.classification}</Badge>}
+                  <ChevronRight className="h-4 w-4 text-muted-foreground" />
+                </div>
+              </Link>
+            ))}
+      </CardContent>
+    </Card>
   );
 }

--- a/app/mobility/page.tsx
+++ b/app/mobility/page.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import { Activity, Footprints, Gauge, PersonStanding, TrendingUpDown } from "lucide-react";
+import { useDailyMetrics } from "@/lib/queries/metrics";
+import { PageHeader } from "@/components/dashboard/page-header";
+import { RangeSelect } from "@/components/dashboard/range-select";
+import { StatCard } from "@/components/dashboard/stat-card";
+import { TrendChart } from "@/components/charts/trend-chart";
+import { CardGridSkeleton, ChartSkeleton, QueryView } from "@/components/dashboard/states";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { RangeKey } from "@/lib/queries/ranges";
+import * as fmt from "@/lib/format";
+import { mean, latest } from "@/lib/stats";
+
+export default function MobilityPage() {
+  const [range, setRange] = useState<RangeKey>("90d");
+  const query = useDailyMetrics(range);
+
+  return (
+    <>
+      <PageHeader
+        title="Mobility & Walking"
+        description="Gait quality — walking speed, step length, symmetry and steadiness."
+        actions={<RangeSelect value={range} onChange={setRange} />}
+      />
+
+      <QueryView
+        query={query}
+        loading={
+          <div className="space-y-6">
+            <CardGridSkeleton />
+            <ChartSkeleton />
+          </div>
+        }
+        isEmpty={(d) =>
+          d.every((r) => r.walking_speed_kmh == null && r.walking_steadiness_pct == null)
+        }
+      >
+        {(m) => (
+          <div className="space-y-6">
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              <StatCard label="Walking speed" value={fmt.number(mean(m.map((d) => d.walking_speed_kmh)), 1)} unit="km/h" icon={Gauge} accent="text-chart-1" spark={{ data: m, dataKey: "walking_speed_kmh", color: "var(--chart-1)" }} />
+              <StatCard label="Step length" value={fmt.number(mean(m.map((d) => d.step_length_cm)), 1)} unit="cm" icon={Footprints} accent="text-chart-3" spark={{ data: m, dataKey: "step_length_cm", color: "var(--chart-3)" }} />
+              <StatCard label="Walking steadiness" value={fmt.number(latest(m.map((d) => d.walking_steadiness_pct)), 1)} unit="%" icon={PersonStanding} accent="text-chart-2" spark={{ data: m, dataKey: "walking_steadiness_pct", color: "var(--chart-2)" }} />
+              <StatCard label="Asymmetry" value={fmt.number(mean(m.map((d) => d.walking_asymmetry_pct)), 1)} unit="%" icon={TrendingUpDown} accent="text-chart-4" invertDelta spark={{ data: m, dataKey: "walking_asymmetry_pct", color: "var(--chart-4)" }} />
+            </div>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Walking speed & step length</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <TrendChart
+                  data={m}
+                  series={[
+                    { key: "walking_speed_kmh", label: "Speed (km/h)", type: "line", color: "var(--chart-1)" },
+                    { key: "step_length_cm", label: "Step length (cm)", type: "line", color: "var(--chart-3)" },
+                  ]}
+                  valueFormatter={(v) => v.toFixed(0)}
+                />
+              </CardContent>
+            </Card>
+
+            <div className="grid gap-6 lg:grid-cols-2">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-base">
+                    <Activity className="h-4 w-4 text-chart-4" /> Gait symmetry
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <TrendChart
+                    data={m}
+                    height={260}
+                    series={[
+                      { key: "walking_asymmetry_pct", label: "Asymmetry %", type: "line", color: "var(--chart-4)" },
+                      { key: "double_support_pct", label: "Double support %", type: "line", color: "var(--chart-5)" },
+                    ]}
+                    valueFormatter={(v) => `${v.toFixed(0)}%`}
+                  />
+                </CardContent>
+              </Card>
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-base">Stair speed</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <TrendChart
+                    data={m}
+                    height={260}
+                    series={[
+                      { key: "stair_ascent_speed", label: "Ascent", type: "line", color: "var(--chart-1)" },
+                      { key: "stair_descent_speed", label: "Descent", type: "line", color: "var(--chart-2)" },
+                    ]}
+                    valueFormatter={(v) => v.toFixed(2)}
+                  />
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+        )}
+      </QueryView>
+    </>
+  );
+}

--- a/app/nutrition/page.tsx
+++ b/app/nutrition/page.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState } from "react";
+import { Beef, Coffee, Croissant, Droplet, Flame, Wheat } from "lucide-react";
+import { useDailyMetrics } from "@/lib/queries/metrics";
+import { PageHeader } from "@/components/dashboard/page-header";
+import { RangeSelect } from "@/components/dashboard/range-select";
+import { StatCard } from "@/components/dashboard/stat-card";
+import { TrendChart } from "@/components/charts/trend-chart";
+import { CardGridSkeleton, ChartSkeleton, QueryView } from "@/components/dashboard/states";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { RangeKey } from "@/lib/queries/ranges";
+import * as fmt from "@/lib/format";
+import { mean } from "@/lib/stats";
+
+export default function NutritionPage() {
+  const [range, setRange] = useState<RangeKey>("90d");
+  const query = useDailyMetrics(range);
+
+  return (
+    <>
+      <PageHeader
+        title="Nutrition"
+        description="Calories, macronutrients and intake logged via Apple Health."
+        actions={<RangeSelect value={range} onChange={setRange} />}
+      />
+
+      <QueryView
+        query={query}
+        loading={
+          <div className="space-y-6">
+            <CardGridSkeleton />
+            <ChartSkeleton />
+          </div>
+        }
+        isEmpty={(d) => d.every((r) => r.diet_energy_kcal == null && r.water_ml == null)}
+      >
+        {(m) => (
+          <div className="space-y-6">
+            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              <StatCard label="Avg calories" value={fmt.number(mean(m.map((d) => d.diet_energy_kcal)))} unit="kcal" icon={Flame} accent="text-chart-3" spark={{ data: m, dataKey: "diet_energy_kcal", color: "var(--chart-3)" }} />
+              <StatCard label="Avg protein" value={fmt.number(mean(m.map((d) => d.protein_g)))} unit="g" icon={Beef} accent="text-chart-4" spark={{ data: m, dataKey: "protein_g", color: "var(--chart-4)" }} />
+              <StatCard label="Avg water" value={fmt.number(mean(m.map((d) => d.water_ml)))} unit="ml" icon={Droplet} accent="text-chart-2" spark={{ data: m, dataKey: "water_ml", color: "var(--chart-2)" }} />
+              <StatCard label="Avg caffeine" value={fmt.number(mean(m.map((d) => d.caffeine_mg)))} unit="mg" icon={Coffee} accent="text-chart-5" spark={{ data: m, dataKey: "caffeine_mg", color: "var(--chart-5)" }} />
+            </div>
+
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-base">Energy intake</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <TrendChart data={m} series={[{ key: "diet_energy_kcal", label: "Calories", type: "bar", color: "var(--chart-3)" }]} />
+              </CardContent>
+            </Card>
+
+            <div className="grid gap-6 lg:grid-cols-2">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-base">
+                    <Wheat className="h-4 w-4 text-chart-1" /> Macronutrients
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <TrendChart
+                    data={m}
+                    height={260}
+                    valueFormatter={(v) => `${v.toFixed(0)}g`}
+                    series={[
+                      { key: "carbs_g", label: "Carbs", color: "var(--chart-1)", stackId: "m" },
+                      { key: "protein_g", label: "Protein", color: "var(--chart-4)", stackId: "m" },
+                      { key: "fat_g", label: "Fat", color: "var(--chart-3)", stackId: "m" },
+                    ]}
+                  />
+                </CardContent>
+              </Card>
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-base">
+                    <Croissant className="h-4 w-4 text-chart-5" /> Sugar &amp; fibre
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <TrendChart
+                    data={m}
+                    height={260}
+                    valueFormatter={(v) => `${v.toFixed(0)}g`}
+                    series={[
+                      { key: "sugar_g", label: "Sugar", type: "line", color: "var(--chart-5)" },
+                      { key: "fiber_g", label: "Fibre", type: "line", color: "var(--chart-1)" },
+                    ]}
+                  />
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+        )}
+      </QueryView>
+    </>
+  );
+}

--- a/components/charts/ecg-waveform.tsx
+++ b/components/charts/ecg-waveform.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useMemo } from "react";
+
+/**
+ * Renders an ECG waveform as a single SVG path. Downsamples to keep the DOM
+ * light, and draws the classic pink ECG grid behind the trace.
+ */
+export function EcgWaveform({
+  samples,
+  maxPoints = 2500,
+  height = 240,
+}: {
+  samples: number[];
+  maxPoints?: number;
+  height?: number;
+}) {
+  const { path, viewW } = useMemo(() => {
+    if (!samples.length) return { path: "", viewW: 1000 };
+
+    const step = Math.max(1, Math.ceil(samples.length / maxPoints));
+    const pts: number[] = [];
+    for (let i = 0; i < samples.length; i += step) pts.push(samples[i]);
+
+    let min = Infinity;
+    let max = -Infinity;
+    for (const v of pts) {
+      if (v < min) min = v;
+      if (v > max) max = v;
+    }
+    const range = max - min || 1;
+    const w = pts.length;
+    const h = 100;
+
+    const d = pts
+      .map((v, i) => {
+        const x = (i / (w - 1)) * w;
+        const y = h - ((v - min) / range) * h;
+        return `${i === 0 ? "M" : "L"}${x.toFixed(1)} ${y.toFixed(1)}`;
+      })
+      .join(" ");
+
+    return { path: d, viewW: w };
+  }, [samples, maxPoints]);
+
+  if (!path) return null;
+
+  return (
+    <div
+      className="w-full overflow-hidden rounded-xl border"
+      style={{ height, background: "color-mix(in oklab, var(--chart-4) 6%, var(--card))" }}
+    >
+      <svg
+        viewBox={`0 0 ${viewW} 100`}
+        preserveAspectRatio="none"
+        width="100%"
+        height="100%"
+        role="img"
+        aria-label="ECG waveform"
+      >
+        <defs>
+          <pattern id="ecg-grid" width="10" height="10" patternUnits="userSpaceOnUse">
+            <path
+              d="M10 0 L0 0 0 10"
+              fill="none"
+              stroke="var(--chart-4)"
+              strokeWidth="0.3"
+              opacity="0.25"
+            />
+          </pattern>
+        </defs>
+        <rect width={viewW} height="100" fill="url(#ecg-grid)" />
+        <path d={path} fill="none" stroke="var(--chart-4)" strokeWidth="0.6" vectorEffect="non-scaling-stroke" />
+      </svg>
+    </div>
+  );
+}

--- a/components/dashboard/nav.ts
+++ b/components/dashboard/nav.ts
@@ -1,5 +1,15 @@
 import type { LucideIcon } from "lucide-react";
-import { Activity, Dumbbell, HeartPulse, LayoutDashboard, Moon, Scale } from "lucide-react";
+import {
+  Activity,
+  Dumbbell,
+  Ear,
+  HeartPulse,
+  LayoutDashboard,
+  Moon,
+  PersonStanding,
+  Scale,
+  Utensils,
+} from "lucide-react";
 
 export interface NavItem {
   href: string;
@@ -15,5 +25,8 @@ export const NAV_ITEMS: NavItem[] = [
   { href: "/activity", label: "Activity", icon: Activity, accent: "text-chart-1" },
   { href: "/heart", label: "Heart & Vitals", icon: HeartPulse, accent: "text-chart-4" },
   { href: "/sleep", label: "Sleep", icon: Moon, accent: "text-chart-2" },
+  { href: "/mobility", label: "Mobility", icon: PersonStanding, accent: "text-chart-1" },
+  { href: "/nutrition", label: "Nutrition", icon: Utensils, accent: "text-chart-3" },
+  { href: "/hearing", label: "Hearing", icon: Ear, accent: "text-chart-2" },
   { href: "/body", label: "Body", icon: Scale, accent: "text-chart-5" },
 ];

--- a/lib/health/workout-types.ts
+++ b/lib/health/workout-types.ts
@@ -24,6 +24,11 @@ const META: Record<string, WorkoutTypeMeta> = {
   FunctionalStrengthTraining: { label: "Functional Strength", category: "strength", icon: "Dumbbell" },
   CoreTraining: { label: "Core Training", category: "strength", icon: "Dumbbell" },
   Tennis: { label: "Tennis", category: "sport", icon: "Trophy" },
+  TrackAndField: { label: "Track & Field", category: "sport", icon: "Trophy" },
+  Snowboarding: { label: "Snowboarding", category: "sport", icon: "Mountain" },
+  CardioDance: { label: "Cardio Dance", category: "cardio", icon: "Music" },
+  Cooldown: { label: "Cooldown", category: "mind", icon: "Heart" },
+  Play: { label: "Play", category: "sport", icon: "Trophy" },
   Yoga: { label: "Yoga", category: "mind", icon: "Heart" },
   Other: { label: "Other", category: "other", icon: "Activity" },
 };

--- a/lib/queries/ecg.ts
+++ b/lib/queries/ecg.ts
@@ -1,0 +1,38 @@
+import { useQuery } from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+import type { Tables } from "@/lib/supabase/database.types";
+import { queryKeys } from "./keys";
+
+export type Ecg = Tables<"ecg">;
+export type EcgSummary = Omit<Ecg, "samples">;
+
+/** ECG list — metadata only (excludes the heavy `samples` waveform). */
+export function useEcgList() {
+  return useQuery({
+    queryKey: queryKeys.ecgList,
+    queryFn: async (): Promise<EcgSummary[]> => {
+      const supabase = createClient();
+      const { data, error } = await supabase
+        .from("ecg")
+        .select(
+          "id, recorded_at, classification, symptoms, sample_rate_hz, average_heart_rate, unit, sample_count, device, software_version, created_at",
+        )
+        .order("recorded_at", { ascending: false });
+      if (error) throw error;
+      return (data ?? []) as EcgSummary[];
+    },
+  });
+}
+
+export function useEcg(id: string) {
+  return useQuery({
+    queryKey: queryKeys.ecg(id),
+    enabled: !!id,
+    queryFn: async (): Promise<Ecg | null> => {
+      const supabase = createClient();
+      const { data, error } = await supabase.from("ecg").select("*").eq("id", id).maybeSingle();
+      if (error) throw error;
+      return data;
+    },
+  });
+}

--- a/lib/queries/keys.ts
+++ b/lib/queries/keys.ts
@@ -10,4 +10,6 @@ export const queryKeys = {
   workoutRoute: (workoutId: string) => ["workout-route", workoutId] as const,
   activitySummaries: (range: RangeKey) => ["activity-summaries", range] as const,
   sleep: (range: RangeKey) => ["sleep", range] as const,
+  ecgList: ["ecg-list"] as const,
+  ecg: (id: string) => ["ecg", id] as const,
 };

--- a/lib/supabase/database.types.ts
+++ b/lib/supabase/database.types.ts
@@ -136,11 +136,57 @@ export interface Database {
           body_fat_pct: number | null;
           sleep_min: number | null;
           sleep_quality: number | null;
+          stand_hours: number | null;
+          basal_energy: number | null;
+          physical_effort: number | null;
+          daylight_min: number | null;
+          distance_cycling_km: number | null;
+          walking_hr_avg: number | null;
+          sleeping_wrist_temp_c: number | null;
+          walking_speed_kmh: number | null;
+          step_length_cm: number | null;
+          walking_asymmetry_pct: number | null;
+          double_support_pct: number | null;
+          stair_ascent_speed: number | null;
+          stair_descent_speed: number | null;
+          walking_steadiness_pct: number | null;
+          env_audio_db: number | null;
+          headphone_audio_db: number | null;
+          diet_energy_kcal: number | null;
+          carbs_g: number | null;
+          protein_g: number | null;
+          fat_g: number | null;
+          sugar_g: number | null;
+          fiber_g: number | null;
+          sodium_mg: number | null;
+          water_ml: number | null;
+          caffeine_mg: number | null;
         };
         Insert: Partial<Database["public"]["Tables"]["daily_metrics"]["Row"]> & {
           date: string;
         };
         Update: Partial<Database["public"]["Tables"]["daily_metrics"]["Row"]>;
+        Relationships: [];
+      };
+      ecg: {
+        Row: {
+          id: string;
+          recorded_at: string;
+          classification: string | null;
+          symptoms: string | null;
+          sample_rate_hz: number | null;
+          average_heart_rate: number | null;
+          unit: string | null;
+          sample_count: number;
+          device: string | null;
+          software_version: string | null;
+          samples: Json;
+          created_at: string;
+        };
+        Insert: Partial<Database["public"]["Tables"]["ecg"]["Row"]> & {
+          recorded_at: string;
+        };
+        Update: Partial<Database["public"]["Tables"]["ecg"]["Row"]>;
         Relationships: [];
       };
     };

--- a/scripts/ingest/__tests__/daily.test.ts
+++ b/scripts/ingest/__tests__/daily.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { DailyAccumulator } from "../daily";
+
+describe("DailyAccumulator", () => {
+  it("sums sum-typed metrics per day", () => {
+    const a = new DailyAccumulator();
+    a.addRecord("2024-01-01", "StepCount", 1000);
+    a.addRecord("2024-01-01", "StepCount", 2500);
+    a.addRecord("2024-01-02", "StepCount", 500);
+    const rows = a.finalize();
+    const d1 = rows.find((r) => r.date === "2024-01-01");
+    const d2 = rows.find((r) => r.date === "2024-01-02");
+    expect(d1?.steps).toBe(3500);
+    expect(d2?.steps).toBe(500);
+  });
+
+  it("averages avg-typed metrics", () => {
+    const a = new DailyAccumulator();
+    a.addRecord("2024-01-01", "HeartRate", 60);
+    a.addRecord("2024-01-01", "HeartRate", 80);
+    expect(a.finalize()[0].avg_heart_rate).toBe(70);
+  });
+
+  it("scales fractional percentages to 0–100", () => {
+    const a = new DailyAccumulator();
+    a.addRecord("2024-01-01", "OxygenSaturation", 0.97);
+    expect(a.finalize()[0].blood_oxygen).toBe(97);
+  });
+
+  it("merges direct (ring/sleep) values", () => {
+    const a = new DailyAccumulator();
+    a.addRecord("2024-01-01", "StepCount", 100);
+    a.setDirect("2024-01-01", "active_energy", 540);
+    a.setDirect("2024-01-01", "sleep_min", 432);
+    const row = a.finalize()[0];
+    expect(row.active_energy).toBe(540);
+    expect(row.sleep_min).toBe(432);
+    expect(row.steps).toBe(100);
+  });
+
+  it("ignores null/unmapped values", () => {
+    const a = new DailyAccumulator();
+    a.addRecord("2024-01-01", "StepCount", null);
+    a.addRecord("2024-01-01", "NotAThing", 5);
+    expect(a.finalize()).toHaveLength(0);
+  });
+});

--- a/scripts/ingest/__tests__/ecg-csv.test.ts
+++ b/scripts/ingest/__tests__/ecg-csv.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import { parseEcgCsv } from "../ecg-csv";
+
+// Mirrors the Japanese-locale layout of a real Apple ECG export.
+const JA_CSV = `名前,Tom Plumpton
+生年月日,"02/03/1997"
+記録日,2019-06-04 15:15:39 +0100
+分類,洞調律
+症状,
+ソフトウェアバージョン,1.13
+デバイス,"Watch4,2"
+サンプルレート,513.406ヘルツ
+
+
+リード,リードI
+単位,µV
+
+-233.043
+-323.883
+120.5`;
+
+describe("parseEcgCsv", () => {
+  const ecg = parseEcgCsv(JA_CSV);
+
+  it("parses the recording timestamp", () => {
+    expect(ecg.recorded_at).toBe("2019-06-04T14:15:39.000Z");
+  });
+
+  it("translates the classification", () => {
+    expect(ecg.classification).toBe("Sinus Rhythm");
+  });
+
+  it("parses sample rate and unit", () => {
+    expect(ecg.sample_rate_hz).toBeCloseTo(513.406, 2);
+    expect(ecg.unit).toBe("µV");
+  });
+
+  it("collects the waveform samples", () => {
+    expect(ecg.sample_count).toBe(3);
+    expect(ecg.samples).toEqual([-233.043, -323.883, 120.5]);
+  });
+});

--- a/scripts/ingest/__tests__/sleep-sessions.test.ts
+++ b/scripts/ingest/__tests__/sleep-sessions.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { buildSleepSessions } from "../sleep-sessions";
+import type { SleepSegment } from "../health-export";
+
+function seg(value: string, start: string, end: string): SleepSegment {
+  return { value, start_time: start, end_time: end, wake_day: end.slice(0, 10), source: "watch" };
+}
+
+describe("buildSleepSessions", () => {
+  it("groups contiguous segments into one night and sums stages", () => {
+    const segments = [
+      seg("HKCategoryValueSleepAnalysisAsleepCore", "2024-01-01T23:00:00Z", "2024-01-01T23:30:00Z"),
+      seg("HKCategoryValueSleepAnalysisAsleepDeep", "2024-01-01T23:30:00Z", "2024-01-02T00:30:00Z"),
+      seg("HKCategoryValueSleepAnalysisAsleepREM", "2024-01-02T00:30:00Z", "2024-01-02T01:00:00Z"),
+      seg("HKCategoryValueSleepAnalysisAwake", "2024-01-02T01:00:00Z", "2024-01-02T01:10:00Z"),
+    ];
+    const { sessions, daily } = buildSleepSessions(segments);
+    expect(sessions).toHaveLength(1);
+    const s = sessions[0];
+    expect(s.deep_min).toBe(60);
+    expect(s.rem_min).toBe(30);
+    expect(s.light_min).toBe(30); // Core -> light
+    expect(s.awake_min).toBe(10);
+    expect(s.duration_min).toBe(120); // asleep = deep+rem+light
+    expect(s.quality_pct).toBeGreaterThan(0);
+    expect(daily[0]).toMatchObject({ date: "2024-01-02", sleep_min: 120 });
+  });
+
+  it("splits sessions separated by a long gap", () => {
+    const segments = [
+      seg("HKCategoryValueSleepAnalysisAsleepCore", "2024-01-01T23:00:00Z", "2024-01-02T06:00:00Z"),
+      // afternoon nap, hours later
+      seg("HKCategoryValueSleepAnalysisAsleepCore", "2024-01-02T14:00:00Z", "2024-01-02T14:40:00Z"),
+    ];
+    const { sessions } = buildSleepSessions(segments);
+    expect(sessions).toHaveLength(2);
+    expect(sessions[1].is_nap).toBe(true);
+  });
+
+  it("ignores in-bed-only groups with no real sleep", () => {
+    const segments = [
+      seg("HKCategoryValueSleepAnalysisInBed", "2024-01-01T23:00:00Z", "2024-01-02T07:00:00Z"),
+    ];
+    expect(buildSleepSessions(segments).sessions).toHaveLength(0);
+  });
+});

--- a/scripts/ingest/daily.ts
+++ b/scripts/ingest/daily.ts
@@ -1,0 +1,79 @@
+import { DAILY_RULES, PCT_COLUMNS } from "./metric-config";
+
+interface Bucket {
+  sum: number;
+  count: number;
+}
+
+/**
+ * Accumulates daily_metrics in memory while the export streams, so the giant
+ * high-frequency series (heart rate, energy, steps) never touch the database —
+ * only their daily roll-ups do.
+ */
+export class DailyAccumulator {
+  private agg = new Map<string, Map<string, Bucket>>(); // date -> column -> bucket
+  private direct = new Map<string, Map<string, number>>(); // date -> column -> value
+
+  private dayAgg(date: string): Map<string, Bucket> {
+    let m = this.agg.get(date);
+    if (!m) this.agg.set(date, (m = new Map()));
+    return m;
+  }
+
+  private dayDirect(date: string): Map<string, number> {
+    let m = this.direct.get(date);
+    if (!m) this.direct.set(date, (m = new Map()));
+    return m;
+  }
+
+  /** Tally a raw record value into its mapped daily column. */
+  addRecord(date: string, type: string, value: number | null) {
+    if (value == null || !Number.isFinite(value)) return;
+    const rule = DAILY_RULES[type];
+    if (!rule) return;
+    const m = this.dayAgg(date);
+    const b = m.get(rule.column) ?? { sum: 0, count: 0 };
+    b.sum += value;
+    b.count += 1;
+    m.set(rule.column, b);
+  }
+
+  /** Set a single-valued daily column (rings, sleep totals). */
+  setDirect(date: string, column: string, value: number | null) {
+    if (value == null || !Number.isFinite(value)) return;
+    this.dayDirect(date).set(column, value);
+  }
+
+  private static round(n: number): number {
+    return Math.round(n * 1000) / 1000;
+  }
+
+  /** Produce daily_metrics insert rows. */
+  finalize(): Array<Record<string, number | string | null>> {
+    const dates = new Set([...this.agg.keys(), ...this.direct.keys()]);
+    const rows: Array<Record<string, number | string | null>> = [];
+
+    for (const date of dates) {
+      const row: Record<string, number | string | null> = { date };
+
+      const aggMap = this.agg.get(date);
+      if (aggMap) {
+        for (const [column, b] of aggMap) {
+          const rule = Object.values(DAILY_RULES).find((r) => r.column === column)!;
+          let v = rule.agg === "sum" ? b.sum : b.count ? b.sum / b.count : null;
+          if (v != null && PCT_COLUMNS.has(column) && v <= 1.5) v *= 100;
+          row[column] = v == null ? null : DailyAccumulator.round(v);
+        }
+      }
+
+      const directMap = this.direct.get(date);
+      if (directMap) {
+        for (const [column, v] of directMap) row[column] = DailyAccumulator.round(v);
+      }
+
+      rows.push(row);
+    }
+
+    return rows;
+  }
+}

--- a/scripts/ingest/ecg-csv.ts
+++ b/scripts/ingest/ecg-csv.ts
@@ -1,0 +1,74 @@
+import { parseHealthDate, parseLeadingNumber } from "./util";
+
+export interface EcgRecord {
+  recorded_at: string | null;
+  classification: string | null;
+  symptoms: string | null;
+  sample_rate_hz: number | null;
+  device: string | null;
+  software_version: string | null;
+  unit: string | null;
+  samples: number[];
+  sample_count: number;
+}
+
+// Apple exports ECG CSVs in the device locale; match keys in EN + JA.
+function classify(key: string): string | null {
+  const k = key.trim();
+  if (/記録日|recorded date|recording date/i.test(k)) return "recordedDate";
+  if (/分類|classification/i.test(k)) return "classification";
+  if (/症状|symptom/i.test(k)) return "symptoms";
+  if (/ソフトウェア|software/i.test(k)) return "software";
+  if (/デバイス|device/i.test(k)) return "device";
+  if (/サンプルレート|sample rate/i.test(k)) return "sampleRate";
+  if (/単位|unit/i.test(k)) return "unit";
+  return null;
+}
+
+// Common Apple ECG classifications (JA -> EN); pass through anything unknown.
+const CLASSIFICATIONS: Record<string, string> = {
+  洞調律: "Sinus Rhythm",
+  心房細動: "Atrial Fibrillation",
+  判定不能: "Inconclusive",
+  高心拍数: "High Heart Rate",
+  低心拍数: "Low Heart Rate",
+};
+
+function unquote(v: string): string {
+  return v.trim().replace(/^"(.*)"$/, "$1").trim();
+}
+
+export function parseEcgCsv(content: string): EcgRecord {
+  const lines = content.split(/\r?\n/);
+  const meta: Record<string, string> = {};
+  const samples: number[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    // A bare numeric line is a waveform sample.
+    if (/^-?\d+(\.\d+)?$/.test(trimmed)) {
+      samples.push(Number(trimmed));
+      continue;
+    }
+
+    const comma = line.indexOf(",");
+    if (comma === -1) continue;
+    const canonical = classify(line.slice(0, comma));
+    if (canonical) meta[canonical] = unquote(line.slice(comma + 1));
+  }
+
+  const rawClass = meta.classification ?? null;
+  return {
+    recorded_at: parseHealthDate(meta.recordedDate),
+    classification: rawClass ? (CLASSIFICATIONS[rawClass] ?? rawClass) : null,
+    symptoms: meta.symptoms || null,
+    sample_rate_hz: parseLeadingNumber(meta.sampleRate),
+    device: meta.device || null,
+    software_version: meta.software || null,
+    unit: meta.unit || null,
+    samples,
+    sample_count: samples.length,
+  };
+}

--- a/scripts/ingest/health-export.ts
+++ b/scripts/ingest/health-export.ts
@@ -30,6 +30,18 @@ export interface RecordRow {
   start_time: string;
   end_time: string | null;
   source: string | null;
+  /** Local calendar date (yyyy-MM-dd) taken from the export's local startDate. */
+  day: string;
+}
+
+export interface SleepSegment {
+  /** Raw HKCategoryValueSleepAnalysis* value. */
+  value: string;
+  start_time: string | null;
+  end_time: string | null;
+  /** Local wake date (end date) used to bucket the night. */
+  wake_day: string;
+  source: string | null;
 }
 
 export interface ActivitySummaryRow {
@@ -53,6 +65,7 @@ export interface ExportHandlers {
   onWorkouts: (rows: WorkoutRow[]) => Promise<void>;
   onRecords: (rows: RecordRow[]) => Promise<void>;
   onActivitySummaries: (rows: ActivitySummaryRow[]) => Promise<void>;
+  onSleepSegments?: (rows: SleepSegment[]) => Promise<void>;
 }
 
 /** Record types worth keeping — the ones that power the dashboard. */
@@ -96,14 +109,20 @@ export async function streamHealthExport(
   filePath: string,
   handlers: ExportHandlers,
   options: StreamOptions = {},
-): Promise<{ workouts: number; records: number; activitySummaries: number }> {
+): Promise<{
+  workouts: number;
+  records: number;
+  activitySummaries: number;
+  sleepSegments: number;
+}> {
   const batchSize = options.batchSize ?? 5000;
   const recordTypes = options.recordTypes ?? DEFAULT_RECORD_TYPES;
 
   const workoutBuf: WorkoutRow[] = [];
   const recordBuf: RecordRow[] = [];
   const activityBuf: ActivitySummaryRow[] = [];
-  const counts = { workouts: 0, records: 0, activitySummaries: 0 };
+  const sleepBuf: SleepSegment[] = [];
+  const counts = { workouts: 0, records: 0, activitySummaries: 0, sleepSegments: 0 };
 
   let current: WorkoutAccumulator | null = null;
   let correlationDepth = 0;
@@ -180,8 +199,24 @@ export async function streamHealthExport(
       case "Record": {
         if (correlationDepth > 0) break; // avoid double-counting nested records
         const type = shortRecordType(a.type as string);
+        const startRaw = a.startDate as string;
+        if (!startRaw) break;
+
+        if (type === "SleepAnalysis") {
+          if (!handlers.onSleepSegments) break;
+          const endRaw = (a.endDate as string) || startRaw;
+          sleepBuf.push({
+            value: (a.value as string) || "",
+            start_time: parseHealthDate(startRaw),
+            end_time: parseHealthDate(endRaw),
+            wake_day: endRaw.slice(0, 10),
+            source: (a.sourceName as string) || null,
+          });
+          break;
+        }
+
         if (!recordTypes.has(type)) break;
-        const start = parseHealthDate(a.startDate as string);
+        const start = parseHealthDate(startRaw);
         if (!start) break;
         recordBuf.push({
           type,
@@ -190,6 +225,7 @@ export async function streamHealthExport(
           start_time: start,
           end_time: parseHealthDate(a.endDate as string),
           source: (a.sourceName as string) || null,
+          day: startRaw.slice(0, 10),
         });
         break;
       }
@@ -243,6 +279,10 @@ export async function streamHealthExport(
       counts.activitySummaries += activityBuf.length;
       await handlers.onActivitySummaries(activityBuf.splice(0));
     }
+    if (sleepBuf.length && handlers.onSleepSegments) {
+      counts.sleepSegments += sleepBuf.length;
+      await handlers.onSleepSegments(sleepBuf.splice(0));
+    }
   };
 
   for await (const chunk of stream) {
@@ -250,7 +290,8 @@ export async function streamHealthExport(
     if (
       recordBuf.length >= batchSize ||
       workoutBuf.length >= batchSize ||
-      activityBuf.length >= batchSize
+      activityBuf.length >= batchSize ||
+      sleepBuf.length >= batchSize
     ) {
       await flush();
     }

--- a/scripts/ingest/index.ts
+++ b/scripts/ingest/index.ts
@@ -2,11 +2,14 @@
  * Apple Health ingestion CLI.
  *
  *   npm run ingest -- --export ./data/export.xml --routes ./data/workout-routes \
- *     [--sleep-csv ./data/fallback/sleep.csv] [--tz Europe/London] [--no-reset]
+ *     [--ecg ./data/electrocardiograms] [--sleep-csv ./data/fallback/sleep.csv] \
+ *     [--tz Europe/London] [--no-reset]
  *
- * Streams export.xml, loads workouts / records / activity summaries, links GPX
- * routes, loads sleep, then rebuilds daily_metrics. Writes via the Supabase
- * secret key (bypasses RLS). Re-runnable: resets the data tables first by default.
+ * Streams export.xml, tallying the giant high-frequency series (heart rate,
+ * energy, steps…) into in-memory daily roll-ups so they never hit the database —
+ * only a small set of low-volume series are stored raw. Builds sleep sessions
+ * from native SleepAnalysis, links GPX routes, loads ECG recordings, then writes
+ * daily_metrics. Re-runnable: resets the data tables first by default.
  */
 import { readdir, readFile, stat } from "node:fs/promises";
 import { join, resolve } from "node:path";
@@ -17,8 +20,13 @@ import {
   streamHealthExport,
   type ActivitySummaryRow,
   type RecordRow,
+  type SleepSegment,
   type WorkoutRow,
 } from "./health-export";
+import { DailyAccumulator } from "./daily";
+import { ingestRecordTypes, RAW_TYPES } from "./metric-config";
+import { buildSleepSessions } from "./sleep-sessions";
+import { parseEcgCsv } from "./ecg-csv";
 import { parseGpx } from "./gpx";
 import { parseSleepCsv } from "./sleep-csv";
 
@@ -27,6 +35,7 @@ type DB = SupabaseClient<Database>;
 interface Args {
   export?: string;
   routes?: string;
+  ecg?: string;
   sleepCsv?: string;
   tz: string;
   reset: boolean;
@@ -34,12 +43,13 @@ interface Args {
 }
 
 function parseArgs(argv: string[]): Args {
-  const args: Args = { tz: "Europe/London", reset: true, batch: 2000 };
+  const args: Args = { tz: "Europe/London", reset: true, batch: 5000 };
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     const next = () => argv[++i];
     if (a === "--export") args.export = next();
     else if (a === "--routes") args.routes = next();
+    else if (a === "--ecg") args.ecg = next();
     else if (a === "--sleep-csv") args.sleepCsv = next();
     else if (a === "--tz") args.tz = next() ?? args.tz;
     else if (a === "--batch") args.batch = Number(next()) || args.batch;
@@ -79,9 +89,18 @@ async function insertChunked<T>(
   }
 }
 
-async function ingestExport(db: DB, file: string, batch: number) {
+async function ingestExport(db: DB, file: string, batch: number, daily: DailyAccumulator) {
   console.log(`→ Streaming ${file} …`);
-  let lastLog = Date.now();
+  const segments: SleepSegment[] = [];
+  let rawBuf: Database["public"]["Tables"]["health_records"]["Insert"][] = [];
+
+  const flushRaw = async () => {
+    if (rawBuf.length >= 1000) {
+      await insertChunked(db, "health_records", rawBuf);
+      rawBuf = [];
+    }
+  };
+
   const counts = await streamHealthExport(
     file,
     {
@@ -91,20 +110,55 @@ async function ingestExport(db: DB, file: string, batch: number) {
       onWorkouts: (rows: WorkoutRow[]) =>
         insertChunked(db, "workouts", rows, { onConflict: "activity_type,start_time" }),
       onRecords: async (rows: RecordRow[]) => {
-        await insertChunked(db, "health_records", rows);
-        if (Date.now() - lastLog > 3000) {
-          process.stdout.write(`   …records streamed\r`);
-          lastLog = Date.now();
+        for (const r of rows) {
+          daily.addRecord(r.day, r.type, r.value);
+          if (RAW_TYPES.has(r.type)) {
+            rawBuf.push({
+              type: r.type,
+              unit: r.unit,
+              value: r.value,
+              start_time: r.start_time,
+              end_time: r.end_time,
+              source: r.source,
+            });
+          }
+        }
+        await flushRaw();
+      },
+      onActivitySummaries: async (rows: ActivitySummaryRow[]) => {
+        await insertChunked(db, "activity_summaries", rows, { onConflict: "date" });
+        for (const a of rows) {
+          daily.setDirect(a.date, "active_energy", a.active_energy_kcal);
+          daily.setDirect(a.date, "exercise_min", a.exercise_min);
+          daily.setDirect(a.date, "stand_hours", a.stand_hours);
         }
       },
-      onActivitySummaries: (rows: ActivitySummaryRow[]) =>
-        insertChunked(db, "activity_summaries", rows, { onConflict: "date" }),
+      onSleepSegments: async (rows: SleepSegment[]) => {
+        segments.push(...rows);
+      },
     },
-    { batchSize: batch },
+    { batchSize: batch, recordTypes: ingestRecordTypes() },
   );
+
+  if (rawBuf.length) await insertChunked(db, "health_records", rawBuf);
+
   console.log(
-    `✓ Export: ${counts.workouts} workouts, ${counts.records} records, ${counts.activitySummaries} activity summaries`,
+    `✓ Export: ${counts.workouts} workouts, ${counts.records} records kept raw, ` +
+      `${counts.activitySummaries} activity days, ${counts.sleepSegments} sleep segments`,
   );
+  return segments;
+}
+
+async function ingestSleepSegments(db: DB, segments: SleepSegment[], daily: DailyAccumulator) {
+  if (!segments.length) return false;
+  const { sessions, daily: sleepDaily } = buildSleepSessions(segments);
+  await insertChunked(db, "sleep_sessions", sessions, { onConflict: "start_time" });
+  for (const d of sleepDaily) {
+    daily.setDirect(d.date, "sleep_min", d.sleep_min);
+    daily.setDirect(d.date, "sleep_quality", d.sleep_quality);
+  }
+  console.log(`✓ Sleep: ${sessions.length} sessions from native SleepAnalysis`);
+  return true;
 }
 
 async function ingestRoutes(db: DB, dir: string) {
@@ -114,14 +168,13 @@ async function ingestRoutes(db: DB, dir: string) {
     return;
   }
 
-  // Build a lookup of workout id + start epoch to match routes by time.
   const { data: workouts, error } = await db.from("workouts").select("id, start_time");
   if (error) die(`Could not load workouts for route matching: ${error.message}`);
   const index = (workouts ?? [])
     .map((w) => ({ id: w.id, t: new Date(w.start_time).getTime() }))
     .sort((a, b) => a.t - b.t);
 
-  const TOLERANCE_MS = 2 * 60 * 60 * 1000; // 2 hours
+  const TOLERANCE_MS = 2 * 60 * 60 * 1000;
   const routeRows: Database["public"]["Tables"]["workout_routes"]["Insert"][] = [];
   let matched = 0;
 
@@ -138,7 +191,6 @@ async function ingestRoutes(db: DB, dir: string) {
     }
     const workoutId = best && best.diff <= TOLERANCE_MS ? best.id : null;
     if (workoutId) matched++;
-
     routeRows.push({
       workout_id: workoutId,
       source: "Apple Health Export",
@@ -150,39 +202,66 @@ async function ingestRoutes(db: DB, dir: string) {
     });
   }
 
-  // Only one route per workout (unique workout_id) — drop unmatched dupes.
   const seen = new Set<string>();
   const deduped = routeRows.filter((r) => {
-    if (!r.workout_id) return false;
-    if (seen.has(r.workout_id)) return false;
+    if (!r.workout_id || seen.has(r.workout_id)) return false;
     seen.add(r.workout_id);
     return true;
   });
 
   await insertChunked(db, "workout_routes", deduped, { onConflict: "workout_id" });
-  console.log(`✓ Routes: ${deduped.length} linked to workouts (${matched} matched of ${files.length} files)`);
+  console.log(`✓ Routes: ${deduped.length} linked (${matched} matched of ${files.length} files)`);
 }
 
-async function ingestSleep(db: DB, csvPath: string) {
-  const rows = parseSleepCsv(await readFile(csvPath, "utf8"));
+async function ingestEcg(db: DB, dir: string) {
+  const files = (await readdir(dir)).filter((f) => f.toLowerCase().endsWith(".csv"));
+  const rows: Database["public"]["Tables"]["ecg"]["Insert"][] = [];
+  for (const f of files) {
+    const e = parseEcgCsv(await readFile(join(dir, f), "utf8"));
+    if (!e.recorded_at || !e.sample_count) continue;
+    rows.push({
+      recorded_at: e.recorded_at,
+      classification: e.classification,
+      symptoms: e.symptoms,
+      sample_rate_hz: e.sample_rate_hz,
+      unit: e.unit,
+      device: e.device,
+      software_version: e.software_version,
+      sample_count: e.sample_count,
+      samples: e.samples,
+    });
+  }
   if (!rows.length) {
-    console.log("→ No sleep rows parsed; skipping.");
+    console.log("→ No ECG recordings parsed; skipping.");
     return;
   }
+  await insertChunked(db, "ecg", rows, { onConflict: "recorded_at" });
+  console.log(`✓ ECG: ${rows.length} recordings`);
+}
+
+async function ingestSleepCsv(db: DB, csvPath: string, daily: DailyAccumulator) {
+  const rows = parseSleepCsv(await readFile(csvPath, "utf8"));
+  if (!rows.length) return;
   await insertChunked(db, "sleep_sessions", rows, { onConflict: "start_time" });
-  console.log(`✓ Sleep: ${rows.length} sessions`);
+  for (const r of rows) {
+    if (!r.is_nap && r.end_time) {
+      const day = r.end_time.slice(0, 10);
+      daily.setDirect(day, "sleep_min", r.duration_min ?? 0);
+      daily.setDirect(day, "sleep_quality", r.quality_pct);
+    }
+  }
+  console.log(`✓ Sleep: ${rows.length} sessions from Pillow CSV (fallback)`);
 }
 
 async function main() {
   loadEnv();
   const args = parseArgs(process.argv.slice(2));
-  if (!args.export) {
-    die("Missing --export <path to export.xml>. See scripts/ingest/index.ts for usage.");
-  }
+  if (!args.export) die("Missing --export <path to export.xml>.");
   const exportPath = resolve(args.export);
   if (!(await exists(exportPath))) die(`Export file not found: ${exportPath}`);
 
   const db = createServiceClient();
+  const daily = new DailyAccumulator();
 
   if (args.reset) {
     console.log("→ Resetting data tables …");
@@ -190,25 +269,25 @@ async function main() {
     if (error) die(`reset_health_data failed: ${error.message}`);
   }
 
-  await ingestExport(db, exportPath, args.batch);
+  const segments = await ingestExport(db, exportPath, args.batch, daily);
+
+  const haveNativeSleep = await ingestSleepSegments(db, segments, daily);
 
   if (args.routes && (await exists(resolve(args.routes)))) {
     await ingestRoutes(db, resolve(args.routes));
-  } else if (args.routes) {
-    console.log(`→ Routes dir not found: ${args.routes}; skipping.`);
   }
 
-  // Sleep: explicit CSV, else the bundled Pillow fallback if present.
-  const sleepPath = args.sleepCsv ?? "data/fallback/sleep.csv";
-  if (await exists(resolve(sleepPath))) {
-    await ingestSleep(db, resolve(sleepPath));
-  } else {
-    console.log("→ No sleep CSV found; skipping sleep.");
+  const ecgDir = args.ecg ?? join(exportPath, "..", "electrocardiograms");
+  if (await exists(ecgDir)) await ingestEcg(db, ecgDir);
+
+  // Native SleepAnalysis wins; fall back to the Pillow CSV only if absent.
+  if (!haveNativeSleep) {
+    const sleepPath = args.sleepCsv ?? "data/fallback/sleep.csv";
+    if (await exists(resolve(sleepPath))) await ingestSleepCsv(db, resolve(sleepPath), daily);
   }
 
-  console.log(`→ Rebuilding daily_metrics (tz=${args.tz}) …`);
-  const { error: rollupErr } = await db.rpc("refresh_daily_metrics", { tz: args.tz });
-  if (rollupErr) die(`refresh_daily_metrics failed: ${rollupErr.message}`);
+  console.log("→ Writing daily_metrics …");
+  await insertChunked(db, "daily_metrics", daily.finalize(), { onConflict: "date" });
 
   console.log("\n✓ Ingest complete.\n");
 }

--- a/scripts/ingest/metric-config.ts
+++ b/scripts/ingest/metric-config.ts
@@ -1,0 +1,86 @@
+// Maps HealthKit record types to daily_metrics columns and how to aggregate
+// them. High-frequency series are tallied in memory (never stored raw); a small
+// set of low-volume series are ALSO kept raw in health_records for drill-down.
+
+export type Agg = "sum" | "avg";
+
+export interface DailyRule {
+  column: string;
+  agg: Agg;
+  /** Multiply by 100 when the source value is a 0–1 fraction. */
+  pct?: boolean;
+}
+
+/** shortType -> daily rollup rule. */
+export const DAILY_RULES: Record<string, DailyRule> = {
+  StepCount: { column: "steps", agg: "sum" },
+  DistanceWalkingRunning: { column: "distance_km", agg: "sum" },
+  DistanceCycling: { column: "distance_cycling_km", agg: "sum" },
+  FlightsClimbed: { column: "flights_climbed", agg: "sum" },
+  BasalEnergyBurned: { column: "basal_energy", agg: "sum" },
+  HeartRate: { column: "avg_heart_rate", agg: "avg" },
+  RestingHeartRate: { column: "resting_hr", agg: "avg" },
+  WalkingHeartRateAverage: { column: "walking_hr_avg", agg: "avg" },
+  HeartRateVariabilitySDNN: { column: "hrv_ms", agg: "avg" },
+  VO2Max: { column: "vo2max", agg: "avg" },
+  OxygenSaturation: { column: "blood_oxygen", agg: "avg", pct: true },
+  RespiratoryRate: { column: "respiratory_rate", agg: "avg" },
+  BodyMass: { column: "weight_kg", agg: "avg" },
+  BodyMassIndex: { column: "bmi", agg: "avg" },
+  BodyFatPercentage: { column: "body_fat_pct", agg: "avg", pct: true },
+  PhysicalEffort: { column: "physical_effort", agg: "avg" },
+  TimeInDaylight: { column: "daylight_min", agg: "sum" },
+  AppleSleepingWristTemperature: { column: "sleeping_wrist_temp_c", agg: "avg" },
+  // mobility / gait
+  WalkingSpeed: { column: "walking_speed_kmh", agg: "avg" },
+  WalkingStepLength: { column: "step_length_cm", agg: "avg" },
+  WalkingAsymmetryPercentage: { column: "walking_asymmetry_pct", agg: "avg", pct: true },
+  WalkingDoubleSupportPercentage: { column: "double_support_pct", agg: "avg", pct: true },
+  StairAscentSpeed: { column: "stair_ascent_speed", agg: "avg" },
+  StairDescentSpeed: { column: "stair_descent_speed", agg: "avg" },
+  AppleWalkingSteadiness: { column: "walking_steadiness_pct", agg: "avg", pct: true },
+  // hearing / audio
+  EnvironmentalAudioExposure: { column: "env_audio_db", agg: "avg" },
+  HeadphoneAudioExposure: { column: "headphone_audio_db", agg: "avg" },
+  // nutrition
+  DietaryEnergyConsumed: { column: "diet_energy_kcal", agg: "sum" },
+  DietaryCarbohydrates: { column: "carbs_g", agg: "sum" },
+  DietaryProtein: { column: "protein_g", agg: "sum" },
+  DietaryFatTotal: { column: "fat_g", agg: "sum" },
+  DietarySugar: { column: "sugar_g", agg: "sum" },
+  DietaryFiber: { column: "fiber_g", agg: "sum" },
+  DietarySodium: { column: "sodium_mg", agg: "sum" },
+  DietaryWater: { column: "water_ml", agg: "sum" },
+  DietaryCaffeine: { column: "caffeine_mg", agg: "sum" },
+};
+
+/**
+ * Low-volume types also kept raw in health_records (a few thousand rows each),
+ * so we can build intra-day / point views later without re-architecting.
+ */
+export const RAW_TYPES = new Set([
+  "RestingHeartRate",
+  "HeartRateVariabilitySDNN",
+  "VO2Max",
+  "OxygenSaturation",
+  "BodyMass",
+  "BodyMassIndex",
+  "BodyFatPercentage",
+  "WalkingHeartRateAverage",
+  "AppleWalkingSteadiness",
+  "SixMinuteWalkTestDistance",
+  "HeartRateRecoveryOneMinute",
+  "AppleSleepingWristTemperature",
+]);
+
+/** Columns whose final daily value is a percentage that may arrive as a fraction. */
+export const PCT_COLUMNS = new Set(
+  Object.values(DAILY_RULES)
+    .filter((r) => r.pct)
+    .map((r) => r.column),
+);
+
+/** Every type the streamer should surface (daily-mapped ∪ raw). */
+export function ingestRecordTypes(): Set<string> {
+  return new Set([...Object.keys(DAILY_RULES), ...RAW_TYPES]);
+}

--- a/scripts/ingest/sleep-sessions.ts
+++ b/scripts/ingest/sleep-sessions.ts
@@ -1,0 +1,142 @@
+import type { SleepSegment } from "./health-export";
+
+export interface SleepSessionRow {
+  start_time: string;
+  end_time: string | null;
+  duration_min: number;
+  quality_pct: number | null;
+  awake_min: number;
+  rem_min: number;
+  light_min: number;
+  deep_min: number;
+  sounds_recorded: number | null;
+  mood: string | null;
+  is_nap: boolean;
+  source: string;
+}
+
+export interface SleepDaily {
+  date: string;
+  sleep_min: number;
+  sleep_quality: number | null;
+}
+
+type Stage = "deep" | "rem" | "light" | "awake" | "inBed" | null;
+
+function stageOf(value: string): Stage {
+  if (value.includes("Deep")) return "deep";
+  if (value.includes("REM")) return "rem";
+  if (value.includes("Core") || value.includes("Unspecified")) return "light";
+  if (value.endsWith("Asleep")) return "light"; // legacy generic "Asleep"
+  if (value.includes("Awake")) return "awake";
+  if (value.includes("InBed")) return "inBed";
+  return null;
+}
+
+const GAP_MS = 60 * 60 * 1000; // a >1h gap starts a new sleep session
+
+interface Group {
+  start: number;
+  end: number;
+  source: string | null;
+  wakeDay: string;
+  deep: number;
+  rem: number;
+  light: number;
+  awake: number;
+  inBed: number;
+}
+
+function minutes(start: string | null, end: string | null): number {
+  if (!start || !end) return 0;
+  const ms = new Date(end).getTime() - new Date(start).getTime();
+  return ms > 0 ? ms / 60000 : 0;
+}
+
+/**
+ * Group raw sleep segments into nightly sessions and per-day rollups. Sessions
+ * are split on gaps over an hour; asleep time = deep + rem + light, quality is
+ * sleep efficiency against the in-bed (or asleep+awake) window.
+ */
+export function buildSleepSessions(segments: SleepSegment[]): {
+  sessions: SleepSessionRow[];
+  daily: SleepDaily[];
+} {
+  const valid = segments
+    .filter((s) => s.start_time && s.end_time)
+    .sort((a, b) => new Date(a.start_time!).getTime() - new Date(b.start_time!).getTime());
+
+  const groups: Group[] = [];
+  let cur: Group | null = null;
+
+  for (const seg of valid) {
+    const start = new Date(seg.start_time!).getTime();
+    const end = new Date(seg.end_time!).getTime();
+    const stage = stageOf(seg.value);
+    const mins = minutes(seg.start_time, seg.end_time);
+
+    if (!cur || start - cur.end > GAP_MS) {
+      cur = {
+        start,
+        end,
+        source: seg.source,
+        wakeDay: seg.wake_day,
+        deep: 0,
+        rem: 0,
+        light: 0,
+        awake: 0,
+        inBed: 0,
+      };
+      groups.push(cur);
+    }
+    cur.end = Math.max(cur.end, end);
+    cur.wakeDay = seg.wake_day;
+    if (stage && stage !== "inBed") cur[stage] += mins;
+    else if (stage === "inBed") cur.inBed += mins;
+  }
+
+  const round = (n: number) => Math.round(n);
+  const sessions: SleepSessionRow[] = [];
+  const dailyMap = new Map<string, { sleep: number; qSum: number; qCount: number }>();
+
+  for (const g of groups) {
+    const asleep = g.deep + g.rem + g.light;
+    if (asleep === 0) continue; // in-bed only, no actual sleep recorded
+    const denom = Math.max(g.inBed, asleep + g.awake);
+    const quality = denom > 0 ? Math.min(100, (asleep / denom) * 100) : null;
+    const isNap = asleep < 90;
+
+    sessions.push({
+      start_time: new Date(g.start).toISOString(),
+      end_time: new Date(g.end).toISOString(),
+      duration_min: round(asleep),
+      quality_pct: quality == null ? null : round(quality),
+      awake_min: round(g.awake),
+      rem_min: round(g.rem),
+      light_min: round(g.light),
+      deep_min: round(g.deep),
+      sounds_recorded: null,
+      mood: null,
+      is_nap: isNap,
+      source: g.source ?? "Apple Health",
+    });
+
+    if (!isNap) {
+      const d = dailyMap.get(g.wakeDay) ?? { sleep: 0, qSum: 0, qCount: 0 };
+      d.sleep += asleep;
+      if (quality != null) {
+        d.qSum += quality;
+        d.qCount += 1;
+      }
+      dailyMap.set(g.wakeDay, d);
+    }
+  }
+
+  const daily: SleepDaily[] = [...dailyMap.entries()].map(([date, d]) => ({
+    date,
+    sleep_min: round(d.sleep),
+    sleep_quality: d.qCount ? round(d.qSum / d.qCount) : null,
+  }));
+
+  return { sessions, daily };
+}

--- a/supabase/migrations/20260617130000_health_v2.sql
+++ b/supabase/migrations/20260617130000_health_v2.sql
@@ -1,0 +1,55 @@
+-- Schema v2: richer daily metrics (mobility, nutrition, audio, etc.) plus ECG.
+-- Driven by a HealthKit v14 export which carries far more than cardio + sleep.
+
+alter table public.daily_metrics
+  add column if not exists stand_hours          numeric,
+  add column if not exists basal_energy         numeric,
+  add column if not exists physical_effort       numeric,
+  add column if not exists daylight_min          numeric,
+  add column if not exists distance_cycling_km   numeric,
+  add column if not exists walking_hr_avg        numeric,
+  add column if not exists sleeping_wrist_temp_c numeric,
+  -- mobility / gait
+  add column if not exists walking_speed_kmh     numeric,
+  add column if not exists step_length_cm        numeric,
+  add column if not exists walking_asymmetry_pct numeric,
+  add column if not exists double_support_pct    numeric,
+  add column if not exists stair_ascent_speed    numeric,
+  add column if not exists stair_descent_speed   numeric,
+  add column if not exists walking_steadiness_pct numeric,
+  -- hearing / audio exposure
+  add column if not exists env_audio_db          numeric,
+  add column if not exists headphone_audio_db    numeric,
+  -- nutrition
+  add column if not exists diet_energy_kcal      numeric,
+  add column if not exists carbs_g               numeric,
+  add column if not exists protein_g             numeric,
+  add column if not exists fat_g                 numeric,
+  add column if not exists sugar_g               numeric,
+  add column if not exists fiber_g               numeric,
+  add column if not exists sodium_mg             numeric,
+  add column if not exists water_ml              numeric,
+  add column if not exists caffeine_mg           numeric;
+
+-- ---------------------------------------------------------------------------
+-- ecg: one row per Apple Watch ECG recording (from electrocardiograms/*.csv)
+-- ---------------------------------------------------------------------------
+create table if not exists public.ecg (
+  id                 uuid primary key default gen_random_uuid(),
+  recorded_at        timestamptz not null,
+  classification     text,
+  symptoms           text,
+  sample_rate_hz     numeric,
+  average_heart_rate numeric,
+  unit               text,
+  sample_count       int not null default 0,
+  device             text,
+  software_version   text,
+  -- full voltage waveform, microvolts
+  samples            jsonb not null default '[]'::jsonb,
+  created_at         timestamptz not null default now(),
+  unique (recorded_at)
+);
+
+alter table public.ecg enable row level security;
+create policy "public read" on public.ecg for select using (true);


### PR DESCRIPTION
Follow-up to #4, built against a real ~2.6 GB HealthKit **v14** export (~6M records, 606 routes, ECG data).

## Why
The fresh export is far richer than cardio+sleep, and storing ~6M raw records would blow past Supabase's free tier. So the ingest now **aggregates high-frequency series to daily roll-ups in memory** (heart rate, energy, steps, distance, gait, audio, nutrition) and keeps only low-volume series raw. Fully reversible — re-run ingest to change strategy.

## What's new
- **Schema v2**: ~25 new `daily_metrics` columns + `ecg` table (public-read RLS).
- **Native sleep**: builds nightly sessions from `SleepAnalysis` stages (Core/Deep/REM/Awake); Pillow CSV is now only a fallback.
- **ECG**: parses `electrocardiograms/*.csv` (EN/JA locale aware) → list on Heart + SVG waveform viewer.
- **New pages**: Mobility & Walking, Nutrition, Hearing.
- **More workout types** (Snowboarding, CardioDance, Track & Field…).
- **+12 Vitest tests** (daily accumulator, sleep sessions, ECG parser) — 33 total.

## Verification
`npm run build` ✅ (13 routes) · `npm test` ✅ (33/33) · `tsc --noEmit` ✅ · `npm run lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)