### PR TITLE
Live-data fixes: workout calories, route linking, sleep dedup, ingest robustness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/app/workouts/page.tsx
+++ b/app/workouts/page.tsx
@@ -30,10 +30,13 @@ import type { RangeKey } from "@/lib/queries/ranges";
 import * as fmt from "@/lib/format";
 import { sum } from "@/lib/stats";
 import {
+  CATEGORY_ACCENT,
   CATEGORY_LABELS,
   workoutMeta,
   type WorkoutCategory,
 } from "@/lib/health/workout-types";
+import { WorkoutIcon } from "@/components/dashboard/workout-icon";
+import { cn } from "@/lib/utils";
 
 type CategoryFilter = WorkoutCategory | "all";
 
@@ -135,7 +138,10 @@ export default function WorkoutsPage() {
                       return (
                         <TableRow key={w.id} className="cursor-pointer">
                           <TableCell className="pl-6">
-                            <Link href={`/workouts/${w.id}`} className="flex items-center gap-2 font-medium hover:underline">
+                            <Link href={`/workouts/${w.id}`} className="flex items-center gap-2.5 font-medium hover:underline">
+                              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted">
+                                <WorkoutIcon name={meta.icon} className={cn("h-4 w-4", CATEGORY_ACCENT[meta.category])} />
+                              </span>
                               {meta.label}
                               <Badge variant="secondary" className="text-[10px]">
                                 {CATEGORY_LABELS[meta.category]}

--- a/components/dashboard/workout-icon.tsx
+++ b/components/dashboard/workout-icon.tsx
@@ -1,0 +1,32 @@
+import {
+  Activity,
+  Bike,
+  Dumbbell,
+  Flame,
+  Footprints,
+  Heart,
+  Mountain,
+  Music,
+  Trophy,
+  Waves,
+  type LucideIcon,
+} from "lucide-react";
+
+// Names match the `icon` field in lib/health/workout-types.ts.
+const ICONS: Record<string, LucideIcon> = {
+  Activity,
+  Bike,
+  Dumbbell,
+  Flame,
+  Footprints,
+  Heart,
+  Mountain,
+  Music,
+  Trophy,
+  Waves,
+};
+
+export function WorkoutIcon({ name, className }: { name: string; className?: string }) {
+  const Icon = ICONS[name] ?? Activity;
+  return <Icon className={className} />;
+}

--- a/lib/health/workout-types.ts
+++ b/lib/health/workout-types.ts
@@ -64,3 +64,11 @@ export const CATEGORY_LABELS: Record<WorkoutCategory, string> = {
   mind: "Mind & Body",
   other: "Other",
 };
+
+export const CATEGORY_ACCENT: Record<WorkoutCategory, string> = {
+  cardio: "text-chart-1",
+  strength: "text-chart-3",
+  sport: "text-chart-4",
+  mind: "text-chart-2",
+  other: "text-muted-foreground",
+};

--- a/scripts/ingest/__tests__/fixtures/workout-v14.xml
+++ b/scripts/ingest/__tests__/fixtures/workout-v14.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<HealthData locale="en_GB">
+ <ExportDate value="2024-03-02 10:00:00 +0000"/>
+ <Workout workoutActivityType="HKWorkoutActivityTypeRunning" duration="30" durationUnit="min"
+          sourceName="Tom’s Apple Watch" startDate="2024-03-01 07:00:00 +0000" endDate="2024-03-01 07:30:00 +0000">
+   <MetadataEntry key="HKTimeZone" value="Europe/London"/>
+   <WorkoutStatistics type="HKQuantityTypeIdentifierActiveEnergyBurned" sum="320.5" unit="kcal"/>
+   <WorkoutStatistics type="HKQuantityTypeIdentifierDistanceWalkingRunning" sum="5.2" unit="km"/>
+   <WorkoutStatistics type="HKQuantityTypeIdentifierHeartRate" average="150" maximum="172" unit="count/min"/>
+ </Workout>
+</HealthData>

--- a/scripts/ingest/__tests__/gpx.test.ts
+++ b/scripts/ingest/__tests__/gpx.test.ts
@@ -20,8 +20,8 @@ describe("parseGpx", () => {
     expect(s).toBeLessThanOrEqual(n);
   });
 
-  it("uses the metadata time as start", () => {
-    expect(route.startTime).toBe("2020-08-23T17:40:02Z");
+  it("uses the first track-point time as start (not the export metadata time)", () => {
+    expect(route.startTime).toBe("2020-07-29T13:51:19Z");
   });
 
   it("computes a non-negative distance", () => {

--- a/scripts/ingest/__tests__/health-export.test.ts
+++ b/scripts/ingest/__tests__/health-export.test.ts
@@ -64,3 +64,27 @@ describe("streamHealthExport", () => {
     expect(profile?.biological_sex).toBe("Male");
   });
 });
+
+describe("streamHealthExport — HealthKit v14 WorkoutStatistics", () => {
+  it("reads energy and distance from WorkoutStatistics, not Workout attrs", async () => {
+    const workouts: WorkoutRow[] = [];
+    await streamHealthExport(
+      join(__dirname, "fixtures/workout-v14.xml"),
+      {
+        onWorkouts: async (rows) => {
+          workouts.push(...rows);
+        },
+        onRecords: async () => {},
+        onActivitySummaries: async () => {},
+      },
+      { batchSize: 10 },
+    );
+    expect(workouts).toHaveLength(1);
+    const w = workouts[0];
+    expect(w.activity_type).toBe("Running");
+    expect(w.energy_kcal).toBeCloseTo(320.5, 1);
+    expect(w.distance_km).toBeCloseTo(5.2, 1);
+    expect(w.avg_heart_rate).toBe(150);
+    expect(w.max_heart_rate).toBe(172);
+  });
+});

--- a/scripts/ingest/__tests__/sleep-sessions.test.ts
+++ b/scripts/ingest/__tests__/sleep-sessions.test.ts
@@ -2,8 +2,8 @@ import { describe, expect, it } from "vitest";
 import { buildSleepSessions } from "../sleep-sessions";
 import type { SleepSegment } from "../health-export";
 
-function seg(value: string, start: string, end: string): SleepSegment {
-  return { value, start_time: start, end_time: end, wake_day: end.slice(0, 10), source: "watch" };
+function seg(value: string, start: string, end: string, source = "watch"): SleepSegment {
+  return { value, start_time: start, end_time: end, wake_day: end.slice(0, 10), source };
 }
 
 describe("buildSleepSessions", () => {
@@ -35,6 +35,23 @@ describe("buildSleepSessions", () => {
     const { sessions } = buildSleepSessions(segments);
     expect(sessions).toHaveLength(2);
     expect(sessions[1].is_nap).toBe(true);
+  });
+
+  it("uses the dominant source instead of summing overlapping ones", () => {
+    // iPhone logs a coarse 'Asleep' envelope; the Watch logs granular stages
+    // for the same night. Totals must not double.
+    const segments = [
+      seg("HKCategoryValueSleepAnalysisInBed", "2024-01-01T23:00:00Z", "2024-01-02T07:00:00Z", "iphone"),
+      seg("HKCategoryValueSleepAnalysisAsleepCore", "2024-01-01T23:10:00Z", "2024-01-02T03:00:00Z", "watch"),
+      seg("HKCategoryValueSleepAnalysisAsleepDeep", "2024-01-02T03:00:00Z", "2024-01-02T04:30:00Z", "watch"),
+      seg("HKCategoryValueSleepAnalysisAsleepREM", "2024-01-02T04:30:00Z", "2024-01-02T06:50:00Z", "watch"),
+    ];
+    const { sessions, daily } = buildSleepSessions(segments);
+    expect(sessions).toHaveLength(1);
+    // watch is granular -> wins; asleep = 230 + 90 + 140 = 460, not ~940
+    expect(sessions[0].source).toBe("watch");
+    expect(sessions[0].duration_min).toBe(460);
+    expect(daily[0].sleep_min).toBe(460);
   });
 
   it("ignores in-bed-only groups with no real sleep", () => {

--- a/scripts/ingest/gpx.ts
+++ b/scripts/ingest/gpx.ts
@@ -63,6 +63,8 @@ export function parseGpx(xml: string): ParsedRoute {
     points,
     bounds: points.length ? [west, south, east, north] : null,
     distanceKm: Math.round(distanceKm * 1000) / 1000,
-    startTime: metadataTime ?? firstTrkptTime,
+    // Prefer the first track-point time: Apple sets <metadata><time> to the
+    // export timestamp, not the route's actual start.
+    startTime: firstTrkptTime ?? metadataTime,
   };
 }

--- a/scripts/ingest/health-export.ts
+++ b/scripts/ingest/health-export.ts
@@ -189,10 +189,20 @@ export async function streamHealthExport(
       }
       case "WorkoutStatistics": {
         if (!current) break;
+        // HealthKit v14 moved energy/distance off the <Workout> element into
+        // these child stats; older exports use Workout attributes (set above).
         const type = shortRecordType((a.type as string) ?? "");
         if (type === "HeartRate") {
           current.avg_heart_rate = parseLeadingNumber(a.average as string);
           current.max_heart_rate = parseLeadingNumber(a.maximum as string);
+        } else if (type === "ActiveEnergyBurned") {
+          current.energy_kcal = parseLeadingNumber(a.sum as string);
+        } else if (
+          type === "DistanceWalkingRunning" ||
+          type === "DistanceCycling" ||
+          type === "DistanceSwimming"
+        ) {
+          current.distance_km = parseLeadingNumber(a.sum as string);
         }
         break;
       }

--- a/scripts/ingest/index.ts
+++ b/scripts/ingest/index.ts
@@ -109,9 +109,11 @@ async function ingestExport(db: DB, file: string, batch: number, daily: DailyAcc
   console.log(`→ Streaming ${file} …`);
   const segments: SleepSegment[] = [];
   let rawBuf: Database["public"]["Tables"]["health_records"]["Insert"][] = [];
+  let rawStored = 0;
 
   const flushRaw = async () => {
     if (rawBuf.length >= 1000) {
+      rawStored += rawBuf.length;
       await insertChunked(db, "health_records", rawBuf);
       rawBuf = [];
     }
@@ -156,10 +158,14 @@ async function ingestExport(db: DB, file: string, batch: number, daily: DailyAcc
     { batchSize: batch, recordTypes: ingestRecordTypes() },
   );
 
-  if (rawBuf.length) await insertChunked(db, "health_records", rawBuf);
+  if (rawBuf.length) {
+    rawStored += rawBuf.length;
+    await insertChunked(db, "health_records", rawBuf);
+  }
 
   console.log(
-    `✓ Export: ${counts.workouts} workouts, ${counts.records} records kept raw, ` +
+    `✓ Export: ${counts.workouts} workouts, ${counts.records} records scanned ` +
+      `(${rawStored} kept raw, rest rolled up to daily), ` +
       `${counts.activitySummaries} activity days, ${counts.sleepSegments} sleep segments`,
   );
   return segments;
@@ -184,9 +190,20 @@ async function ingestRoutes(db: DB, dir: string) {
     return;
   }
 
-  const { data: workouts, error } = await db.from("workouts").select("id, start_time");
-  if (error) die(`Could not load workouts for route matching: ${error.message}`);
-  const index = (workouts ?? [])
+  // PostgREST caps a select at ~1000 rows, so page through every workout.
+  const workouts: { id: string; start_time: string }[] = [];
+  for (let from = 0; ; from += 1000) {
+    const { data, error } = await db
+      .from("workouts")
+      .select("id, start_time")
+      .order("start_time")
+      .range(from, from + 999);
+    if (error) die(`Could not load workouts for route matching: ${error.message}`);
+    if (!data?.length) break;
+    workouts.push(...data);
+    if (data.length < 1000) break;
+  }
+  const index = workouts
     .map((w) => ({ id: w.id, t: new Date(w.start_time).getTime() }))
     .sort((a, b) => a.t - b.t);
 

--- a/scripts/ingest/index.ts
+++ b/scripts/ingest/index.ts
@@ -72,15 +72,31 @@ async function exists(p: string): Promise<boolean> {
   }
 }
 
+/**
+ * Drop rows that share a conflict key, keeping the last. Apple Health exports
+ * can contain duplicate workouts/records (same source re-imported); without this
+ * an upsert hits "ON CONFLICT DO UPDATE command cannot affect row a second time".
+ */
+function dedupeByKey<T>(rows: T[], conflict: string): T[] {
+  const cols = conflict.split(",").map((c) => c.trim());
+  const map = new Map<string, T>();
+  for (const r of rows) {
+    const key = cols.map((c) => String((r as Record<string, unknown>)[c])).join("|");
+    map.set(key, r);
+  }
+  return [...map.values()];
+}
+
 async function insertChunked<T>(
   db: DB,
   table: keyof Database["public"]["Tables"],
   rows: T[],
   opts?: { onConflict?: string },
 ) {
+  const input = opts?.onConflict ? dedupeByKey(rows, opts.onConflict) : rows;
   const size = 1000;
-  for (let i = 0; i < rows.length; i += size) {
-    const chunk = rows.slice(i, i + size) as never[];
+  for (let i = 0; i < input.length; i += size) {
+    const chunk = input.slice(i, i + size) as never[];
     const q = db.from(table);
     const { error } = opts?.onConflict
       ? await q.upsert(chunk, { onConflict: opts.onConflict, ignoreDuplicates: false })

--- a/scripts/ingest/sleep-sessions.ts
+++ b/scripts/ingest/sleep-sessions.ts
@@ -35,16 +35,20 @@ function stageOf(value: string): Stage {
 
 const GAP_MS = 60 * 60 * 1000; // a >1h gap starts a new sleep session
 
-interface Group {
+interface SourceAcc {
   start: number;
   end: number;
-  source: string | null;
-  wakeDay: string;
   deep: number;
   rem: number;
   light: number;
   awake: number;
   inBed: number;
+}
+
+interface Group {
+  end: number; // latest end seen across any source (for gap detection)
+  wakeDay: string;
+  bySource: Map<string, SourceAcc>;
 }
 
 function minutes(start: string | null, end: string | null): number {
@@ -53,10 +57,28 @@ function minutes(start: string | null, end: string | null): number {
   return ms > 0 ? ms / 60000 : 0;
 }
 
+/** Pick the most complete recording for a night: prefer a source with granular
+ * stages (deep/rem), then the one with the most time asleep. */
+function dominantSource(bySource: Map<string, SourceAcc>): { name: string; acc: SourceAcc } | null {
+  let best: { name: string; acc: SourceAcc; asleep: number; granular: boolean } | null = null;
+  for (const [name, acc] of bySource) {
+    const asleep = acc.deep + acc.rem + acc.light;
+    const granular = acc.deep > 0 || acc.rem > 0;
+    if (
+      !best ||
+      (granular && !best.granular) ||
+      (granular === best.granular && asleep > best.asleep)
+    ) {
+      best = { name, acc, asleep, granular };
+    }
+  }
+  return best ? { name: best.name, acc: best.acc } : null;
+}
+
 /**
- * Group raw sleep segments into nightly sessions and per-day rollups. Sessions
- * are split on gaps over an hour; asleep time = deep + rem + light, quality is
- * sleep efficiency against the in-bed (or asleep+awake) window.
+ * Group raw sleep segments into nightly sessions. When more than one source
+ * (e.g. iPhone + Apple Watch) records the same night, we use only the dominant
+ * source's stages rather than summing them — otherwise totals roughly double.
  */
 export function buildSleepSessions(segments: SleepSegment[]): {
   sessions: SleepSessionRow[];
@@ -74,25 +96,24 @@ export function buildSleepSessions(segments: SleepSegment[]): {
     const end = new Date(seg.end_time!).getTime();
     const stage = stageOf(seg.value);
     const mins = minutes(seg.start_time, seg.end_time);
+    const src = seg.source ?? "Apple Health";
 
     if (!cur || start - cur.end > GAP_MS) {
-      cur = {
-        start,
-        end,
-        source: seg.source,
-        wakeDay: seg.wake_day,
-        deep: 0,
-        rem: 0,
-        light: 0,
-        awake: 0,
-        inBed: 0,
-      };
+      cur = { end, wakeDay: seg.wake_day, bySource: new Map() };
       groups.push(cur);
     }
     cur.end = Math.max(cur.end, end);
     cur.wakeDay = seg.wake_day;
-    if (stage && stage !== "inBed") cur[stage] += mins;
-    else if (stage === "inBed") cur.inBed += mins;
+
+    let acc = cur.bySource.get(src);
+    if (!acc) {
+      acc = { start, end, deep: 0, rem: 0, light: 0, awake: 0, inBed: 0 };
+      cur.bySource.set(src, acc);
+    }
+    acc.start = Math.min(acc.start, start);
+    acc.end = Math.max(acc.end, end);
+    if (stage && stage !== "inBed") acc[stage] += mins;
+    else if (stage === "inBed") acc.inBed += mins;
   }
 
   const round = (n: number) => Math.round(n);
@@ -100,25 +121,29 @@ export function buildSleepSessions(segments: SleepSegment[]): {
   const dailyMap = new Map<string, { sleep: number; qSum: number; qCount: number }>();
 
   for (const g of groups) {
-    const asleep = g.deep + g.rem + g.light;
+    const winner = dominantSource(g.bySource);
+    if (!winner) continue;
+    const { deep, rem, light, awake, inBed, start, end } = winner.acc;
+    const asleep = deep + rem + light;
     if (asleep === 0) continue; // in-bed only, no actual sleep recorded
-    const denom = Math.max(g.inBed, asleep + g.awake);
+
+    const denom = Math.max(inBed, asleep + awake);
     const quality = denom > 0 ? Math.min(100, (asleep / denom) * 100) : null;
     const isNap = asleep < 90;
 
     sessions.push({
-      start_time: new Date(g.start).toISOString(),
-      end_time: new Date(g.end).toISOString(),
+      start_time: new Date(start).toISOString(),
+      end_time: new Date(end).toISOString(),
       duration_min: round(asleep),
       quality_pct: quality == null ? null : round(quality),
-      awake_min: round(g.awake),
-      rem_min: round(g.rem),
-      light_min: round(g.light),
-      deep_min: round(g.deep),
+      awake_min: round(awake),
+      rem_min: round(rem),
+      light_min: round(light),
+      deep_min: round(deep),
       sounds_recorded: null,
       mood: null,
       is_nap: isNap,
-      source: g.source ?? "Apple Health",
+      source: winner.name,
     });
 
     if (!isNap) {


### PR DESCRIPTION
Fixes found while ingesting the real ~2.6 GB HealthKit v14 export (follow-up to #4, #5).

## Fixes
- **Workout calories & distance** — HealthKit v14 moved `totalEnergyBurned`/`totalDistance` off `<Workout>` into `<WorkoutStatistics sum=…>`; read them from there. (All 3,403 workouts were showing no calories.) Now 3,398 have energy.
- **GPX route linking** — Apple sets `<metadata><time>` to the *export* timestamp, so 0/606 routes matched. Use the first track-point time instead → **522 routes linked**. Also page through all workouts (PostgREST caps selects at ~1000 rows).
- **Sleep double-counting** — when iPhone + Watch both record a night, use the dominant (granular) source instead of summing. Nightly sleep dropped from ~15 h to a realistic ~7 h.
- **Duplicate-workout upsert crash** — de-dupe batches by conflict key ("ON CONFLICT DO UPDATE command cannot affect row a second time").
- **Workouts table** — per-activity icon chips, colour-coded by category.
- **CI** — run on Node 22.

## Verification
Re-ingested end-to-end and checked against the live DB: calories populated (676,729 kcal total), 522 routes linked, sleep avg ~419 min. `npm test` ✅ (35) · `tsc` ✅ · `build` ✅ · `lint` ✅. Spot-checked the dashboard (workouts KPIs/icons, route map, ECG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)