### PR TITLE
Insights engine, readiness score, fitness age + PR wall, routes map

### DIFF
--- a/app/heart/page.tsx
+++ b/app/heart/page.tsx
@@ -8,6 +8,8 @@ import { useEcgList } from "@/lib/queries/ecg";
 import { PageHeader } from "@/components/dashboard/page-header";
 import { RangeSelect } from "@/components/dashboard/range-select";
 import { StatCard } from "@/components/dashboard/stat-card";
+import { ReadinessCard } from "@/components/dashboard/readiness-card";
+import { computeReadiness } from "@/lib/health/readiness";
 import { TrendChart } from "@/components/charts/trend-chart";
 import { CardGridSkeleton, ChartSkeleton, QueryView } from "@/components/dashboard/states";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -39,7 +41,9 @@ export default function HeartPage() {
         }
         isEmpty={(d) => d.length === 0}
       >
-        {(m) => (
+        {(m) => {
+          const readiness = computeReadiness(m);
+          return (
           <div className="space-y-6">
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
               <StatCard label="Resting HR" value={fmt.number(latest(m.map((d) => d.resting_hr)))} unit="bpm" icon={HeartPulse} accent="text-chart-4" delta={deltaPct(m.map((d) => d.resting_hr), 7)} invertDelta spark={{ data: m, dataKey: "resting_hr", color: "var(--chart-4)" }} />
@@ -48,20 +52,32 @@ export default function HeartPage() {
               <StatCard label="Blood oxygen" value={fmt.number(mean(m.map((d) => d.blood_oxygen)), 1)} unit="%" icon={Droplets} accent="text-chart-2" spark={{ data: m, dataKey: "blood_oxygen", color: "var(--chart-2)" }} />
             </div>
 
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-base">Resting heart rate & HRV</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <TrendChart
-                  data={m}
-                  series={[
-                    { key: "resting_hr", label: "Resting HR", type: "line", color: "var(--chart-4)", unit: "bpm" },
-                    { key: "hrv_ms", label: "HRV", type: "line", color: "var(--chart-1)", unit: "ms" },
-                  ]}
-                />
-              </CardContent>
-            </Card>
+            <div className="grid gap-6 lg:grid-cols-3">
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2 text-base">
+                    <Gauge className="h-4 w-4 text-chart-1" /> Readiness
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <ReadinessCard days={readiness} />
+                </CardContent>
+              </Card>
+              <Card className="lg:col-span-2">
+                <CardHeader>
+                  <CardTitle className="text-base">Resting heart rate & HRV</CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <TrendChart
+                    data={m}
+                    series={[
+                      { key: "resting_hr", label: "Resting HR", type: "line", color: "var(--chart-4)", unit: "bpm" },
+                      { key: "hrv_ms", label: "HRV", type: "line", color: "var(--chart-1)", unit: "ms" },
+                    ]}
+                  />
+                </CardContent>
+              </Card>
+            </div>
 
             <div className="grid gap-6 lg:grid-cols-2">
               <Card>
@@ -84,7 +100,8 @@ export default function HeartPage() {
               </Card>
             </div>
           </div>
-        )}
+          );
+        }}
       </QueryView>
 
       <EcgSection />

--- a/app/insights/page.tsx
+++ b/app/insights/page.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useMemo } from "react";
+import { Lightbulb } from "lucide-react";
+import { useDailyMetrics } from "@/lib/queries/metrics";
+import { deriveInsights } from "@/lib/insights/engine";
+import { PageHeader } from "@/components/dashboard/page-header";
+import { InsightList } from "@/components/dashboard/insight-list";
+import { ChartSkeleton, QueryView } from "@/components/dashboard/states";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function InsightsPage() {
+  const query = useDailyMetrics("1y");
+  const insights = useMemo(() => deriveInsights(query.data ?? []), [query.data]);
+
+  return (
+    <>
+      <PageHeader
+        title="Insights"
+        description="Patterns we found by correlating a year of your daily metrics — how sleep, training and habits move your recovery."
+      />
+
+      <QueryView query={query} loading={<ChartSkeleton className="h-[420px]" />}>
+        {() => (
+          <div className="space-y-6">
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <Lightbulb className="h-4 w-4 text-chart-3" />
+                  What your data is telling you
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <InsightList insights={insights} />
+              </CardContent>
+            </Card>
+
+            <p className="px-1 text-xs text-muted-foreground">
+              Insights are correlations across daily roll-ups, not medical advice. “r” is the
+              Pearson correlation (−1 to 1); only relationships strong enough (|r| ≥ 0.2) and seen
+              across enough days are shown. Correlation isn’t causation.
+            </p>
+          </div>
+        )}
+      </QueryView>
+    </>
+  );
+}

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import { useState } from "react";
+import { Route as RouteIcon } from "lucide-react";
+import { useAllRoutes } from "@/lib/queries/all-routes";
+import { workoutMeta } from "@/lib/health/workout-types";
+import { PageHeader } from "@/components/dashboard/page-header";
+import { QueryView } from "@/components/dashboard/states";
+import { Card, CardContent } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import * as fmt from "@/lib/format";
+
+const AllRoutesMap = dynamic(() => import("@/components/dashboard/all-routes-map"), {
+  ssr: false,
+  loading: () => <Skeleton className="h-[560px] w-full rounded-xl" />,
+});
+
+interface MergedRoute {
+  points: [number, number][];
+  activityType: string;
+  year: number;
+  distanceKm: number;
+}
+
+export default function MapPage() {
+  const query = useAllRoutes();
+  const [sport, setSport] = useState("all");
+  const [year, setYear] = useState("all");
+
+  return (
+    <>
+      <PageHeader
+        title="Routes Map"
+        description="Every outdoor workout you've recorded, overlaid into a single map of your training ground."
+      />
+
+      <QueryView
+        query={query}
+        loading={<Skeleton className="h-[560px] w-full rounded-xl" />}
+        isEmpty={(d) => d.routes.length === 0}
+      >
+        {(data) => {
+          const metaById = new Map(data.workouts.map((w) => [w.id, w]));
+
+          const merged: MergedRoute[] = data.routes
+            .map((r) => {
+              const pts = (r.points as [number, number][] | null) ?? [];
+              if (pts.length < 2) return null;
+              const w = r.workout_id ? metaById.get(r.workout_id) : undefined;
+              return {
+                points: pts,
+                activityType: w?.activity_type ?? "Other",
+                year: w?.start_time ? new Date(w.start_time).getFullYear() : 0,
+                distanceKm: r.distance_km ?? 0,
+              };
+            })
+            .filter((r): r is MergedRoute => r != null);
+
+          const sports = Array.from(new Set(merged.map((r) => r.activityType))).sort();
+          const years = Array.from(new Set(merged.map((r) => r.year).filter(Boolean))).sort(
+            (a, b) => b - a,
+          );
+
+          const filtered = merged.filter(
+            (r) =>
+              (sport === "all" || r.activityType === sport) &&
+              (year === "all" || r.year === Number(year)),
+          );
+
+          const totalDistance = filtered.reduce((s, r) => s + r.distanceKm, 0);
+
+          return (
+            <div className="space-y-4">
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                <div className="flex flex-wrap gap-4">
+                  <Stat label="Routes" value={fmt.number(filtered.length)} />
+                  <Stat label="Distance" value={`${fmt.number(totalDistance)} km`} />
+                  <Stat label="Sports" value={fmt.number(sports.length)} />
+                </div>
+                <div className="flex items-center gap-2">
+                  <Select value={sport} onValueChange={setSport}>
+                    <SelectTrigger className="w-[150px]">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All sports</SelectItem>
+                      {sports.map((s) => (
+                        <SelectItem key={s} value={s}>
+                          {workoutMeta(s).label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Select value={year} onValueChange={setYear}>
+                    <SelectTrigger className="w-[120px]">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All years</SelectItem>
+                      {years.map((y) => (
+                        <SelectItem key={y} value={String(y)}>
+                          {y}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <Card className="overflow-hidden">
+                <CardContent className="p-0">
+                  <AllRoutesMap routes={filtered} />
+                </CardContent>
+              </Card>
+
+              <p className="flex items-center gap-1.5 px-1 text-xs text-muted-foreground">
+                <RouteIcon className="h-3.5 w-3.5" />
+                Brighter areas are where your routes overlap most. Lines are simplified for
+                performance.
+              </p>
+            </div>
+          );
+        }}
+      </QueryView>
+    </>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-xl font-semibold tabular-nums">{value}</p>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,8 +18,13 @@ import {
   Trophy,
   Wind,
 } from "lucide-react";
+import { Lightbulb } from "lucide-react";
 import { useOverview } from "@/lib/queries/overview";
 import { useWorkouts } from "@/lib/queries/workouts";
+import { deriveInsights } from "@/lib/insights/engine";
+import { computeReadiness } from "@/lib/health/readiness";
+import { InsightList } from "@/components/dashboard/insight-list";
+import { ReadinessCard } from "@/components/dashboard/readiness-card";
 import { PageHeader } from "@/components/dashboard/page-header";
 import { StatCard } from "@/components/dashboard/stat-card";
 import { ActivityRings } from "@/components/dashboard/activity-rings";
@@ -92,6 +97,8 @@ export default function OverviewPage() {
             if (ex >= 30) activeDates.add(row.date);
           }
           const streak = streakStats(activeDates);
+          const insights = deriveInsights(year);
+          const readiness = computeReadiness(year);
 
           return (
             <div className="space-y-6">
@@ -209,6 +216,37 @@ export default function OverviewPage() {
                   delta={deltaPct(m.map((d) => d.sleep_min), 7)}
                   spark={{ data: m, dataKey: "sleep_min", color: "var(--chart-2)" }}
                 />
+              </div>
+
+              {/* Insights + readiness */}
+              <div className="grid gap-6 lg:grid-cols-3">
+                <Card className="lg:col-span-2">
+                  <CardHeader className="flex-row items-center justify-between">
+                    <CardTitle className="flex items-center gap-2 text-base">
+                      <Lightbulb className="h-4 w-4 text-chart-3" />
+                      Insights
+                    </CardTitle>
+                    <Link href="/insights" className="text-xs text-muted-foreground hover:text-foreground">
+                      View all →
+                    </Link>
+                  </CardHeader>
+                  <CardContent>
+                    <InsightList insights={insights.slice(0, 3)} />
+                  </CardContent>
+                </Card>
+
+                <Card>
+                  <CardHeader className="flex-row items-center justify-between">
+                    <CardTitle className="flex items-center gap-2 text-base">
+                      <Gauge className="h-4 w-4 text-chart-1" />
+                      Readiness
+                    </CardTitle>
+                    <span className="text-xs text-muted-foreground">Today</span>
+                  </CardHeader>
+                  <CardContent>
+                    <ReadinessCard days={readiness} />
+                  </CardContent>
+                </Card>
               </div>
 
               {/* Heatmap + recent workouts */}

--- a/app/records/page.tsx
+++ b/app/records/page.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+import {
+  Flame,
+  Footprints,
+  Gauge,
+  HeartPulse,
+  Moon,
+  Route,
+  Timer,
+  TrendingUp,
+  Trophy,
+  Zap,
+} from "lucide-react";
+import { useProfile } from "@/lib/queries/profile";
+import { useRecords, type RecordDailyRow } from "@/lib/queries/records";
+import {
+  ageFromDob,
+  fitnessAge,
+  normaliseSex,
+  restingHrRating,
+  vo2Rating,
+} from "@/lib/health/fitness";
+import { buildRecords, type DailyTops } from "@/lib/health/records";
+import { PageHeader } from "@/components/dashboard/page-header";
+import { CardGridSkeleton, QueryView } from "@/components/dashboard/states";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
+
+const RECORD_ICONS: Record<string, LucideIcon> = {
+  Route,
+  Zap,
+  Flame,
+  Footprints,
+  Timer,
+  Gauge,
+  Moon,
+  TrendingUp,
+};
+
+function topOf(daily: RecordDailyRow[], key: keyof RecordDailyRow) {
+  let best: { date: string | null; value: number } | null = null;
+  for (const r of daily) {
+    const v = r[key];
+    if (typeof v !== "number") continue;
+    if (best == null || v > best.value) best = { date: r.date, value: v };
+  }
+  return best;
+}
+
+function lastNonNull(daily: RecordDailyRow[], key: keyof RecordDailyRow): number | null {
+  for (let i = daily.length - 1; i >= 0; i--) {
+    const v = daily[i][key];
+    if (typeof v === "number") return v;
+  }
+  return null;
+}
+
+export default function RecordsPage() {
+  const recordsQ = useRecords();
+  const profileQ = useProfile();
+
+  return (
+    <>
+      <PageHeader
+        title="Records"
+        description="Your personal bests, and how your cardio fitness stacks up against the norms for your age."
+      />
+
+      <QueryView
+        query={recordsQ}
+        loading={
+          <div className="space-y-6">
+            <Skeleton className="h-40 rounded-xl" />
+            <CardGridSkeleton count={8} />
+          </div>
+        }
+        isEmpty={(d) => d.workouts.length === 0 && d.daily.length === 0}
+      >
+        {(data) => {
+          const tops: DailyTops = {
+            steps: topOf(data.daily, "steps"),
+            active_energy: topOf(data.daily, "active_energy"),
+            exercise_min: topOf(data.daily, "exercise_min"),
+            vo2max: topOf(data.daily, "vo2max"),
+            sleep_min: topOf(data.daily, "sleep_min"),
+            flights_climbed: topOf(data.daily, "flights_climbed"),
+          };
+          const records = buildRecords(data.workouts, tops);
+
+          const profile = profileQ.data;
+          const sex = normaliseSex(profile?.biological_sex);
+          const age = profile?.date_of_birth ? ageFromDob(profile.date_of_birth) : null;
+          const vo2 = lastNonNull(data.daily, "vo2max");
+          const rhr = lastNonNull(data.daily, "resting_hr");
+
+          return (
+            <div className="space-y-8">
+              {vo2 != null && (
+                <FitnessAgeCard vo2={vo2} rhr={rhr} age={age} sex={sex} />
+              )}
+
+              <section>
+                <h2 className="mb-3 flex items-center gap-2 text-lg font-semibold">
+                  <Trophy className="h-5 w-5 text-chart-4" />
+                  Personal records
+                </h2>
+                {records.length === 0 ? (
+                  <p className="text-sm text-muted-foreground">No records to show yet.</p>
+                ) : (
+                  <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                    {records.map((r) => {
+                      const Icon = RECORD_ICONS[r.icon] ?? Trophy;
+                      return (
+                        <Card key={r.key} className="overflow-hidden">
+                          <CardContent className="p-5">
+                            <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+                              <Icon className={cn("h-4 w-4", r.accent)} />
+                              {r.label}
+                            </div>
+                            <p className="mt-2 text-2xl font-semibold tabular-nums">{r.value}</p>
+                            {r.detail && (
+                              <p className="mt-1 truncate text-xs text-muted-foreground">{r.detail}</p>
+                            )}
+                          </CardContent>
+                        </Card>
+                      );
+                    })}
+                  </div>
+                )}
+              </section>
+            </div>
+          );
+        }}
+      </QueryView>
+    </>
+  );
+}
+
+function FitnessAgeCard({
+  vo2,
+  rhr,
+  age,
+  sex,
+}: {
+  vo2: number;
+  rhr: number | null;
+  age: number | null;
+  sex: "male" | "female";
+}) {
+  const fa = fitnessAge(vo2, sex);
+  const vo2r = age != null ? vo2Rating(vo2, age, sex) : null;
+  const hrr = rhr != null ? restingHrRating(rhr) : null;
+  const delta = age != null ? age - fa : null;
+
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Gauge className="h-4 w-4 text-chart-3" />
+          Fitness age
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="grid gap-6 sm:grid-cols-[auto_1fr] sm:items-center sm:gap-10">
+        <div>
+          <div className="flex items-end gap-2">
+            <span className="text-5xl font-semibold tabular-nums leading-none">{fa}</span>
+            <span className="pb-1 text-sm text-muted-foreground">years</span>
+          </div>
+          {delta != null && (
+            <p className="mt-2 text-sm text-muted-foreground">
+              {delta > 0 ? (
+                <span className="font-medium text-emerald-500">{delta} years younger</span>
+              ) : delta < 0 ? (
+                <span className="font-medium text-rose-500">{Math.abs(delta)} years older</span>
+              ) : (
+                <span className="font-medium">on par</span>
+              )}{" "}
+              than your actual age of {age}
+            </p>
+          )}
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <RatingTile
+            icon={Gauge}
+            label="VO₂ Max"
+            value={`${vo2.toFixed(1)}`}
+            unit="ml/kg·min"
+            rating={vo2r?.label}
+            accent={vo2r?.accent ?? "text-chart-3"}
+          />
+          <RatingTile
+            icon={HeartPulse}
+            label="Resting HR"
+            value={rhr != null ? `${Math.round(rhr)}` : "—"}
+            unit="bpm"
+            rating={hrr?.label}
+            accent={hrr?.accent ?? "text-chart-4"}
+          />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function RatingTile({
+  icon: Icon,
+  label,
+  value,
+  unit,
+  rating,
+  accent,
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  unit: string;
+  rating?: string;
+  accent: string;
+}) {
+  return (
+    <div className="rounded-xl border bg-muted/20 p-4">
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <Icon className={cn("h-3.5 w-3.5", accent)} />
+        {label}
+      </div>
+      <p className="mt-1.5 text-2xl font-semibold tabular-nums leading-none">
+        {value} <span className="text-xs font-normal text-muted-foreground">{unit}</span>
+      </p>
+      {rating && <p className={cn("mt-1.5 text-xs font-medium", accent)}>{rating}</p>}
+    </div>
+  );
+}

--- a/components/dashboard/all-routes-map.tsx
+++ b/components/dashboard/all-routes-map.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useMemo } from "react";
+import Map, { Layer, Source, type LayerProps } from "react-map-gl/maplibre";
+import type { StyleSpecification } from "maplibre-gl";
+
+// Free OpenStreetMap raster tiles — no API key, no billing.
+const OSM_STYLE: StyleSpecification = {
+  version: 8,
+  sources: {
+    osm: {
+      type: "raster",
+      tiles: ["https://tile.openstreetmap.org/{z}/{x}/{y}.png"],
+      tileSize: 256,
+      attribution: "© OpenStreetMap contributors",
+    },
+  },
+  layers: [{ id: "osm", type: "raster", source: "osm" }],
+};
+
+// Semi-transparent lines so overlapping routes build up into a heat-like glow.
+const glowLayer: LayerProps = {
+  id: "routes-glow",
+  type: "line",
+  layout: { "line-cap": "round", "line-join": "round" },
+  paint: { "line-color": "#f97316", "line-width": 5, "line-opacity": 0.08, "line-blur": 3 },
+};
+const lineLayer: LayerProps = {
+  id: "routes-line",
+  type: "line",
+  layout: { "line-cap": "round", "line-join": "round" },
+  paint: { "line-color": "#fb923c", "line-width": 1.6, "line-opacity": 0.5 },
+};
+
+export interface MapRoute {
+  points: [number, number][];
+}
+
+const MAX_POINTS_PER_ROUTE = 120;
+
+export default function AllRoutesMap({
+  routes,
+  height = 560,
+}: {
+  routes: MapRoute[];
+  height?: number;
+}) {
+  const { geojson, bounds } = useMemo(() => {
+    let minLng = Infinity;
+    let minLat = Infinity;
+    let maxLng = -Infinity;
+    let maxLat = -Infinity;
+
+    const features = routes
+      .map((route) => {
+        const pts = route.points;
+        if (!Array.isArray(pts) || pts.length < 2) return null;
+        const stride = Math.max(1, Math.ceil(pts.length / MAX_POINTS_PER_ROUTE));
+        const coords: [number, number][] = [];
+        for (let i = 0; i < pts.length; i += stride) {
+          const [lng, lat] = pts[i];
+          if (lng < minLng) minLng = lng;
+          if (lat < minLat) minLat = lat;
+          if (lng > maxLng) maxLng = lng;
+          if (lat > maxLat) maxLat = lat;
+          coords.push([lng, lat]);
+        }
+        // ensure the final point is kept so lines close visually
+        const last = pts[pts.length - 1];
+        coords.push([last[0], last[1]]);
+        return {
+          type: "Feature" as const,
+          properties: {},
+          geometry: { type: "LineString" as const, coordinates: coords },
+        };
+      })
+      .filter((f): f is NonNullable<typeof f> => f != null);
+
+    const validBounds =
+      Number.isFinite(minLng) && Number.isFinite(minLat)
+        ? ([minLng, minLat, maxLng, maxLat] as [number, number, number, number])
+        : null;
+
+    return {
+      geojson: { type: "FeatureCollection" as const, features },
+      bounds: validBounds,
+    };
+  }, [routes]);
+
+  const initialViewState = useMemo(() => {
+    if (bounds) return { bounds, fitBoundsOptions: { padding: 48 } };
+    return { longitude: 0, latitude: 51.5, zoom: 9 };
+  }, [bounds]);
+
+  if (!geojson.features.length) {
+    return (
+      <div
+        className="flex items-center justify-center rounded-xl border text-sm text-muted-foreground"
+        style={{ height }}
+      >
+        No routes match this filter.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border" style={{ height }}>
+      <Map
+        key={geojson.features.length}
+        initialViewState={initialViewState}
+        mapStyle={OSM_STYLE}
+        style={{ width: "100%", height: "100%" }}
+      >
+        <Source id="all-routes" type="geojson" data={geojson}>
+          <Layer {...glowLayer} />
+          <Layer {...lineLayer} />
+        </Source>
+      </Map>
+    </div>
+  );
+}

--- a/components/dashboard/insight-list.tsx
+++ b/components/dashboard/insight-list.tsx
@@ -1,0 +1,40 @@
+import { TrendingDown, TrendingUp } from "lucide-react";
+import type { Insight } from "@/lib/insights/engine";
+import { cn } from "@/lib/utils";
+
+export function InsightList({ insights }: { insights: Insight[] }) {
+  if (!insights.length) {
+    return (
+      <p className="py-6 text-center text-sm text-muted-foreground">
+        Not enough overlapping data yet to spot reliable patterns.
+      </p>
+    );
+  }
+
+  return (
+    <ul className="space-y-3">
+      {insights.map((ins) => (
+        <li key={ins.id} className="flex items-start gap-3 rounded-lg border bg-muted/20 p-3">
+          <span
+            className={cn(
+              "mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted",
+              ins.accent,
+            )}
+          >
+            {ins.sentiment === "positive" ? (
+              <TrendingUp className="h-4 w-4" />
+            ) : (
+              <TrendingDown className="h-4 w-4" />
+            )}
+          </span>
+          <div className="min-w-0">
+            <p className="text-sm leading-snug">{ins.text}</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {ins.tag} · r {ins.r.toFixed(2)} · {ins.n} days
+            </p>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/components/dashboard/nav.ts
+++ b/components/dashboard/nav.ts
@@ -5,9 +5,12 @@ import {
   Ear,
   HeartPulse,
   LayoutDashboard,
+  Lightbulb,
+  Map,
   Moon,
   PersonStanding,
   Scale,
+  Trophy,
   Utensils,
 } from "lucide-react";
 
@@ -21,7 +24,9 @@ export interface NavItem {
 
 export const NAV_ITEMS: NavItem[] = [
   { href: "/", label: "Overview", icon: LayoutDashboard, accent: "text-chart-1" },
+  { href: "/insights", label: "Insights", icon: Lightbulb, accent: "text-chart-3" },
   { href: "/workouts", label: "Workouts", icon: Dumbbell, accent: "text-chart-3" },
+  { href: "/map", label: "Routes Map", icon: Map, accent: "text-chart-2" },
   { href: "/activity", label: "Activity", icon: Activity, accent: "text-chart-1" },
   { href: "/heart", label: "Heart & Vitals", icon: HeartPulse, accent: "text-chart-4" },
   { href: "/sleep", label: "Sleep", icon: Moon, accent: "text-chart-2" },
@@ -29,4 +34,5 @@ export const NAV_ITEMS: NavItem[] = [
   { href: "/nutrition", label: "Nutrition", icon: Utensils, accent: "text-chart-3" },
   { href: "/hearing", label: "Hearing", icon: Ear, accent: "text-chart-2" },
   { href: "/body", label: "Body", icon: Scale, accent: "text-chart-5" },
+  { href: "/records", label: "Records", icon: Trophy, accent: "text-chart-4" },
 ];

--- a/components/dashboard/readiness-card.tsx
+++ b/components/dashboard/readiness-card.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { ReadinessGauge } from "./readiness-gauge";
+import { Sparkline } from "@/components/charts/sparkline";
+import type { ReadinessDay } from "@/lib/health/readiness";
+
+/** Latest readiness gauge + contributor breakdown + a short trend. */
+export function ReadinessCard({ days }: { days: ReadinessDay[] }) {
+  const scored = days.filter((d) => d.score != null);
+  const latest = scored[scored.length - 1];
+
+  if (!latest) {
+    return (
+      <p className="py-6 text-center text-sm text-muted-foreground">
+        Not enough HRV, resting-HR or sleep data yet to score readiness.
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-5">
+      <ReadinessGauge score={latest.score} />
+
+      <div className="w-full space-y-2">
+        {latest.contributors.map((c) => (
+          <div key={c.key} className="flex items-center gap-3 text-xs">
+            <span className="w-24 shrink-0 text-muted-foreground">{c.label}</span>
+            <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-muted">
+              <div
+                className="h-full rounded-full bg-foreground/60"
+                style={{ width: `${Math.round(c.score)}%` }}
+              />
+            </div>
+            <span className="w-7 shrink-0 text-right tabular-nums">{Math.round(c.score)}</span>
+          </div>
+        ))}
+      </div>
+
+      {scored.length > 2 && (
+        <div className="w-full">
+          <p className="mb-1 text-[11px] text-muted-foreground">Last 30 days</p>
+          <Sparkline
+            data={scored.slice(-30).map((d) => ({ date: d.date, score: d.score }))}
+            dataKey="score"
+            color="var(--chart-1)"
+            height={36}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/dashboard/readiness-gauge.tsx
+++ b/components/dashboard/readiness-gauge.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { motion } from "motion/react";
+import { readinessBand } from "@/lib/health/readiness";
+import { cn } from "@/lib/utils";
+
+/** 270° radial gauge for a 0..100 readiness score. */
+export function ReadinessGauge({ score, size = 168 }: { score: number | null; size?: number }) {
+  const r = 52;
+  const circumference = 2 * Math.PI * r;
+  const arcLen = circumference * 0.75; // 270° track, gap at the bottom
+  const pct = score == null ? 0 : Math.max(0, Math.min(score, 100)) / 100;
+  const band = score == null ? null : readinessBand(score);
+  const color = band?.color ?? "var(--muted-foreground)";
+
+  return (
+    <div className="relative" style={{ width: size, height: size }}>
+      <svg viewBox="0 0 120 120" width={size} height={size}>
+        <g transform="rotate(135 60 60)">
+          <circle
+            cx={60}
+            cy={60}
+            r={r}
+            fill="none"
+            stroke="var(--border)"
+            strokeWidth={10}
+            strokeLinecap="round"
+            strokeDasharray={`${arcLen} ${circumference}`}
+          />
+          <motion.circle
+            cx={60}
+            cy={60}
+            r={r}
+            fill="none"
+            stroke={color}
+            strokeWidth={10}
+            strokeLinecap="round"
+            strokeDasharray={`${arcLen} ${circumference}`}
+            initial={{ strokeDashoffset: arcLen }}
+            animate={{ strokeDashoffset: arcLen * (1 - pct) }}
+            transition={{ duration: 1, ease: "easeOut" }}
+          />
+        </g>
+      </svg>
+      <div className="absolute inset-0 flex flex-col items-center justify-center">
+        <span className="text-4xl font-semibold tabular-nums leading-none">{score ?? "—"}</span>
+        <span className={cn("mt-1.5 text-xs font-medium", band?.accent ?? "text-muted-foreground")}>
+          {band?.label ?? "No data"}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/lib/__tests__/fitness.test.ts
+++ b/lib/__tests__/fitness.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  ageFromDob,
+  expectedVo2,
+  fitnessAge,
+  normaliseSex,
+  restingHrRating,
+  vo2Rating,
+} from "@/lib/health/fitness";
+import { buildRecords, type RecordWorkout } from "@/lib/health/records";
+
+describe("fitness age & ratings", () => {
+  it("normalises sex from Apple's strings", () => {
+    expect(normaliseSex("HKBiologicalSexFemale")).toBe("female");
+    expect(normaliseSex("Female")).toBe("female");
+    expect(normaliseSex("Male")).toBe("male");
+    expect(normaliseSex(null)).toBe("male");
+  });
+
+  it("computes age from a date of birth", () => {
+    const now = new Date(2026, 5, 18); // 18 Jun 2026
+    expect(ageFromDob("1997-03-02", now)).toBe(29);
+    expect(ageFromDob("1997-12-25", now)).toBe(28); // birthday not yet reached
+  });
+
+  it("returns a younger fitness age for above-median VO₂ max", () => {
+    // A 45yo male median is ~39; someone at 48 should read much younger.
+    const fa = fitnessAge(48, "male");
+    expect(fa).toBeLessThanOrEqual(25);
+  });
+
+  it("returns an older fitness age for below-median VO₂ max", () => {
+    const fa = fitnessAge(31, "male"); // ~65yo male median
+    expect(fa).toBeGreaterThanOrEqual(60);
+  });
+
+  it("rates VO₂ max relative to the age/sex median", () => {
+    expect(vo2Rating(expectedVo2(40, "male") * 1.2, 40, "male").label).toBe("Superior");
+    expect(vo2Rating(expectedVo2(40, "male") * 0.7, 40, "male").label).toBe("Below average");
+  });
+
+  it("rates resting heart rate", () => {
+    expect(restingHrRating(45).label).toBe("Athlete");
+    expect(restingHrRating(60).label).toBe("Good");
+    expect(restingHrRating(80).label).toBe("Elevated");
+  });
+});
+
+describe("buildRecords", () => {
+  const workouts: RecordWorkout[] = [
+    { activity_type: "Running", distance_km: 10, duration_min: 60, energy_kcal: 600, start_time: "2024-03-01T08:00:00Z" },
+    { activity_type: "Running", distance_km: 5, duration_min: 25, energy_kcal: 350, start_time: "2024-04-01T08:00:00Z" }, // 5:00/km — fastest
+    { activity_type: "Cycling", distance_km: 40, duration_min: 90, energy_kcal: 800, start_time: "2024-05-01T08:00:00Z" }, // longest + biggest burn
+  ];
+
+  it("picks longest distance, fastest pace and biggest burn correctly", () => {
+    const recs = buildRecords(workouts, {});
+    const byKey = Object.fromEntries(recs.map((r) => [r.key, r]));
+    expect(byKey["longest-distance"].detail).toContain("Cycling");
+    expect(byKey["biggest-burn"].value).toContain("800");
+    expect(byKey["fastest-pace"].detail).toContain("Running");
+    expect(byKey["fastest-pace"].value).toContain("5:00");
+  });
+
+  it("emits daily-peak records only when present", () => {
+    const recs = buildRecords([], { steps: { date: "2024-02-02", value: 28000 } });
+    expect(recs.map((r) => r.key)).toEqual(["most-steps"]);
+    expect(recs[0].value).toBe("28,000");
+  });
+});

--- a/lib/__tests__/insights.test.ts
+++ b/lib/__tests__/insights.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { deriveInsights, pearson } from "@/lib/insights/engine";
+import type { DailyMetric } from "@/lib/queries/metrics";
+
+const mk = (date: string, fields: Partial<DailyMetric>): DailyMetric =>
+  ({ date, ...fields }) as unknown as DailyMetric;
+
+describe("pearson", () => {
+  it("is +1 for a perfect positive relationship", () => {
+    expect(pearson([1, 2, 3, 4], [2, 4, 6, 8])).toBeCloseTo(1, 5);
+  });
+
+  it("is -1 for a perfect negative relationship", () => {
+    expect(pearson([1, 2, 3, 4], [8, 6, 4, 2])).toBeCloseTo(-1, 5);
+  });
+
+  it("returns null when a series has no variance", () => {
+    expect(pearson([1, 1, 1, 1], [2, 4, 6, 8])).toBeNull();
+  });
+
+  it("returns null below the minimum sample size", () => {
+    expect(pearson([1, 2], [2, 4])).toBeNull();
+  });
+});
+
+describe("deriveInsights", () => {
+  it("surfaces a strong lagged sleep → resting-HR relationship as positive", () => {
+    // 60 days alternating 6h/8h sleep; next-day resting HR is lower after more
+    // sleep, so the (negative) correlation is the desirable direction.
+    const metrics: DailyMetric[] = [];
+    for (let i = 0; i < 60; i++) {
+      const date = new Date(2024, 0, 1 + i).toISOString().slice(0, 10);
+      const longSleep = i % 2 === 0;
+      metrics.push(
+        mk(date, {
+          sleep_min: longSleep ? 480 : 360,
+          // resting HR depends on *previous* night's sleep
+          resting_hr: i === 0 ? 66 : (i - 1) % 2 === 0 ? 60 : 70,
+        }),
+      );
+    }
+
+    const insights = deriveInsights(metrics);
+    const sleepRhr = insights.find((i) => i.id === "sleep-rhr");
+    expect(sleepRhr).toBeDefined();
+    expect(sleepRhr!.sentiment).toBe("positive");
+    expect(sleepRhr!.text).toContain("lower");
+    expect(sleepRhr!.n).toBeGreaterThanOrEqual(20);
+    expect(sleepRhr!.r).toBeLessThan(0);
+  });
+
+  it("ignores weak or under-sampled relationships", () => {
+    // Only 10 days, random-ish — nothing should clear the thresholds.
+    const metrics = Array.from({ length: 10 }, (_, i) =>
+      mk(new Date(2024, 0, 1 + i).toISOString().slice(0, 10), {
+        sleep_min: 400 + (i % 3) * 5,
+        resting_hr: 62 + (i % 2),
+      }),
+    );
+    expect(deriveInsights(metrics)).toHaveLength(0);
+  });
+
+  it("returns nothing for empty input", () => {
+    expect(deriveInsights([])).toEqual([]);
+  });
+});

--- a/lib/__tests__/readiness.test.ts
+++ b/lib/__tests__/readiness.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import { computeReadiness, readinessBand } from "@/lib/health/readiness";
+import type { DailyMetric } from "@/lib/queries/metrics";
+
+const mk = (date: string, fields: Partial<DailyMetric>): DailyMetric =>
+  ({ date, ...fields }) as unknown as DailyMetric;
+
+/** 40 baseline days (with a little variance) then a great day and an awful day. */
+function buildSeries(): DailyMetric[] {
+  const rows: DailyMetric[] = [];
+  for (let i = 0; i < 40; i++) {
+    rows.push(
+      mk(new Date(2024, 0, 1 + i).toISOString().slice(0, 10), {
+        hrv_ms: i % 2 ? 52 : 48,
+        resting_hr: i % 2 ? 62 : 58,
+        sleep_min: i % 2 ? 490 : 470,
+        exercise_min: 30,
+      }),
+    );
+  }
+  rows.push(mk("2024-02-10", { hrv_ms: 72, resting_hr: 52, sleep_min: 480, exercise_min: 30 }));
+  rows.push(mk("2024-02-11", { hrv_ms: 34, resting_hr: 72, sleep_min: 300, exercise_min: 30 }));
+  return rows;
+}
+
+describe("computeReadiness", () => {
+  it("scores a recovered day far higher than a depleted one", () => {
+    const days = computeReadiness(buildSeries());
+    const good = days[40];
+    const bad = days[41];
+    expect(good.score).not.toBeNull();
+    expect(bad.score).not.toBeNull();
+    expect(good.score!).toBeGreaterThan(bad.score!);
+    expect(good.score!).toBeGreaterThan(80);
+    expect(bad.score!).toBeLessThan(50);
+    expect(good.contributors.map((c) => c.key).sort()).toEqual(["hrv", "load", "rhr", "sleep"]);
+    for (const c of good.contributors) {
+      expect(c.score).toBeGreaterThanOrEqual(0);
+      expect(c.score).toBeLessThanOrEqual(100);
+    }
+  });
+
+  it("still scores early days from sleep before a baseline exists", () => {
+    const days = computeReadiness(buildSeries());
+    const first = days[0];
+    expect(first.score).not.toBeNull();
+    // No prior baseline yet, so HRV/RHR can't be z-scored on day 0.
+    expect(first.contributors.map((c) => c.key)).toContain("sleep");
+    expect(first.contributors.map((c) => c.key)).not.toContain("hrv");
+  });
+
+  it("returns a null score for a day with no usable metrics", () => {
+    const days = computeReadiness([mk("2024-01-01", {})]);
+    expect(days[0].score).toBeNull();
+    expect(days[0].contributors).toEqual([]);
+  });
+});
+
+describe("readinessBand", () => {
+  it("labels the score bands", () => {
+    expect(readinessBand(90).label).toBe("Primed");
+    expect(readinessBand(75).label).toBe("Ready");
+    expect(readinessBand(60).label).toBe("Moderate");
+    expect(readinessBand(40).label).toBe("Take it easy");
+  });
+});

--- a/lib/health/fitness.ts
+++ b/lib/health/fitness.ts
@@ -1,0 +1,104 @@
+export type Sex = "male" | "female";
+
+export interface Rating {
+  label: string;
+  /** Tailwind text-colour token. */
+  accent: string;
+}
+
+/**
+ * Reference median VO₂ max (ml/kg/min) by age, derived from population norms
+ * (Cooper Institute / ACSM-style tables). Used both to rate fitness and to
+ * estimate a "fitness age".
+ */
+const VO2_MEDIANS: Record<Sex, Array<[age: number, median: number]>> = {
+  male: [
+    [25, 48],
+    [35, 43],
+    [45, 39],
+    [55, 35],
+    [65, 31],
+    [75, 27],
+  ],
+  female: [
+    [25, 38],
+    [35, 34],
+    [45, 31],
+    [55, 28],
+    [65, 25],
+    [75, 22],
+  ],
+};
+
+export function normaliseSex(value: string | null | undefined): Sex {
+  return value?.toLowerCase().includes("female") ? "female" : "male";
+}
+
+export function ageFromDob(dob: string, now = new Date()): number {
+  const d = new Date(dob);
+  let age = now.getFullYear() - d.getFullYear();
+  const m = now.getMonth() - d.getMonth();
+  if (m < 0 || (m === 0 && now.getDate() < d.getDate())) age--;
+  return age;
+}
+
+/** Linear interpolation across a sorted [x, y] table, clamped at the ends. */
+function interpolate(points: Array<[number, number]>, x: number): number {
+  if (x <= points[0][0]) return points[0][1];
+  const last = points[points.length - 1];
+  if (x >= last[0]) return last[1];
+  for (let i = 0; i < points.length - 1; i++) {
+    const [x0, y0] = points[i];
+    const [x1, y1] = points[i + 1];
+    if (x >= x0 && x <= x1) {
+      const t = (x - x0) / (x1 - x0);
+      return y0 + t * (y1 - y0);
+    }
+  }
+  return last[1];
+}
+
+/** Expected median VO₂ max for an age + sex. */
+export function expectedVo2(age: number, sex: Sex): number {
+  return interpolate(VO2_MEDIANS[sex], age);
+}
+
+/**
+ * Estimate "fitness age": the age at which the population median VO₂ max equals
+ * this person's. Higher fitness → younger fitness age. Clamped to 20–80.
+ */
+export function fitnessAge(vo2: number, sex: Sex): number {
+  const table = VO2_MEDIANS[sex];
+  if (vo2 >= table[0][1]) return 20;
+  const last = table[table.length - 1];
+  if (vo2 <= last[1]) return 80;
+  // medians decrease with age, so walk pairs and invert.
+  for (let i = 0; i < table.length - 1; i++) {
+    const [a0, m0] = table[i];
+    const [a1, m1] = table[i + 1];
+    if (vo2 <= m0 && vo2 >= m1) {
+      const t = (m0 - vo2) / (m0 - m1);
+      return Math.round(a0 + t * (a1 - a0));
+    }
+  }
+  return last[0];
+}
+
+/** Rate VO₂ max relative to the age/sex median. */
+export function vo2Rating(vo2: number, age: number, sex: Sex): Rating {
+  const ratio = vo2 / expectedVo2(age, sex);
+  if (ratio >= 1.15) return { label: "Superior", accent: "text-chart-1" };
+  if (ratio >= 1.05) return { label: "Excellent", accent: "text-chart-1" };
+  if (ratio >= 0.95) return { label: "Good", accent: "text-chart-2" };
+  if (ratio >= 0.85) return { label: "Fair", accent: "text-chart-3" };
+  return { label: "Below average", accent: "text-chart-4" };
+}
+
+/** Rate resting heart rate (lower is fitter). */
+export function restingHrRating(rhr: number): Rating {
+  if (rhr < 49) return { label: "Athlete", accent: "text-chart-1" };
+  if (rhr <= 55) return { label: "Excellent", accent: "text-chart-1" };
+  if (rhr <= 61) return { label: "Good", accent: "text-chart-2" };
+  if (rhr <= 70) return { label: "Average", accent: "text-chart-3" };
+  return { label: "Elevated", accent: "text-chart-4" };
+}

--- a/lib/health/readiness.ts
+++ b/lib/health/readiness.ts
@@ -1,0 +1,136 @@
+import type { DailyMetric } from "@/lib/queries/metrics";
+
+export interface ReadinessContributor {
+  key: "hrv" | "rhr" | "sleep" | "load";
+  label: string;
+  /** Sub-score 0..100. */
+  score: number;
+}
+
+export interface ReadinessDay {
+  date: string;
+  /** Composite 0..100, or null if nothing could be scored that day. */
+  score: number | null;
+  contributors: ReadinessContributor[];
+}
+
+export interface ReadinessBand {
+  label: string;
+  /** Tailwind text-colour token. */
+  accent: string;
+  /** CSS colour for the gauge arc. */
+  color: string;
+}
+
+const BASELINE_DAYS = 60;
+const MIN_BASELINE = 14;
+const SLEEP_TARGET_MIN = 480; // 8h
+const WEIGHTS: Record<ReadinessContributor["key"], number> = {
+  hrv: 0.35,
+  rhr: 0.25,
+  sleep: 0.3,
+  load: 0.1,
+};
+
+const clamp = (v: number, lo = 0, hi = 100) => Math.max(lo, Math.min(hi, v));
+
+function mean(values: number[]): number {
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+function std(values: number[], mu: number): number {
+  if (values.length < 2) return 0;
+  const variance = values.reduce((a, b) => a + (b - mu) ** 2, 0) / (values.length - 1);
+  return Math.sqrt(variance);
+}
+
+/** Collect up to `BASELINE_DAYS` prior non-null values for a key. */
+function baseline(metrics: DailyMetric[], index: number, key: keyof DailyMetric): number[] {
+  const out: number[] = [];
+  for (let i = index - 1; i >= 0 && out.length < BASELINE_DAYS; i--) {
+    const v = metrics[i][key];
+    if (v != null) out.push(v as number);
+  }
+  return out;
+}
+
+/** Map a z-score to 0..100; `dir` says which direction is favourable. */
+function zScore(value: number, mu: number, sd: number, dir: "higher" | "lower"): number {
+  if (sd === 0) return 50;
+  const z = (value - mu) / sd;
+  return clamp(50 + (dir === "higher" ? 1 : -1) * z * 15);
+}
+
+/**
+ * Daily readiness (Oura/Whoop-style) from HRV and resting HR relative to each
+ * person's own rolling baseline, sleep vs an 8h target, and the prior day's
+ * training load. Expects metrics ordered chronologically (ascending).
+ */
+export function computeReadiness(metrics: DailyMetric[]): ReadinessDay[] {
+  return metrics.map((row, i): ReadinessDay => {
+    const contributors: ReadinessContributor[] = [];
+
+    if (row.hrv_ms != null) {
+      const base = baseline(metrics, i, "hrv_ms");
+      if (base.length >= MIN_BASELINE) {
+        const mu = mean(base);
+        contributors.push({
+          key: "hrv",
+          label: "HRV",
+          score: zScore(row.hrv_ms, mu, std(base, mu), "higher"),
+        });
+      }
+    }
+
+    if (row.resting_hr != null) {
+      const base = baseline(metrics, i, "resting_hr");
+      if (base.length >= MIN_BASELINE) {
+        const mu = mean(base);
+        contributors.push({
+          key: "rhr",
+          label: "Resting HR",
+          score: zScore(row.resting_hr, mu, std(base, mu), "lower"),
+        });
+      }
+    }
+
+    if (row.sleep_min != null) {
+      contributors.push({
+        key: "sleep",
+        label: "Sleep",
+        score: clamp((row.sleep_min / SLEEP_TARGET_MIN) * 100),
+      });
+    }
+
+    // Prior-day training load: a hard day yesterday costs a little readiness.
+    const prev = metrics[i - 1];
+    if (prev?.exercise_min != null) {
+      const base = baseline(metrics, i, "exercise_min");
+      const mu = base.length >= MIN_BASELINE ? mean(base) : 30;
+      const over = Math.max(0, prev.exercise_min - mu);
+      contributors.push({ key: "load", label: "Recovery", score: clamp(100 - (over / 60) * 30, 40) });
+    }
+
+    if (!contributors.length) return { date: row.date, score: null, contributors };
+
+    let weighted = 0;
+    let weightSum = 0;
+    for (const c of contributors) {
+      weighted += c.score * WEIGHTS[c.key];
+      weightSum += WEIGHTS[c.key];
+    }
+
+    return {
+      date: row.date,
+      score: Math.round(weighted / weightSum),
+      contributors,
+    };
+  });
+}
+
+export function readinessBand(score: number): ReadinessBand {
+  if (score >= 85) return { label: "Primed", accent: "text-chart-1", color: "var(--chart-1)" };
+  if (score >= 70) return { label: "Ready", accent: "text-chart-2", color: "var(--chart-2)" };
+  if (score >= 55) return { label: "Moderate", accent: "text-chart-3", color: "var(--chart-3)" };
+  return { label: "Take it easy", accent: "text-chart-4", color: "var(--chart-4)" };
+}

--- a/lib/health/records.ts
+++ b/lib/health/records.ts
@@ -1,0 +1,166 @@
+import * as fmt from "@/lib/format";
+import { workoutMeta } from "@/lib/health/workout-types";
+
+export interface RecordWorkout {
+  activity_type: string;
+  distance_km: number | null;
+  duration_min: number | null;
+  energy_kcal: number | null;
+  start_time: string;
+}
+
+/** A single best-day metric: the peak value and the date it happened. */
+export interface DailyTop {
+  date: string | null;
+  value: number | null;
+}
+
+export interface DailyTops {
+  steps?: DailyTop | null;
+  active_energy?: DailyTop | null;
+  exercise_min?: DailyTop | null;
+  vo2max?: DailyTop | null;
+  sleep_min?: DailyTop | null;
+  flights_climbed?: DailyTop | null;
+}
+
+export interface PersonalRecord {
+  key: string;
+  label: string;
+  value: string;
+  detail?: string;
+  /** lucide icon name; mapped to a component in the UI. */
+  icon: string;
+  accent: string;
+}
+
+function dateLabel(d: string | null | undefined): string | undefined {
+  return d ? fmt.shortDate(d) : undefined;
+}
+
+/** Assemble the personal-records wall from all workouts + per-metric daily peaks. */
+export function buildRecords(workouts: RecordWorkout[], tops: DailyTops): PersonalRecord[] {
+  const records: PersonalRecord[] = [];
+
+  // --- Workout-level records ---
+  const withDistance = workouts.filter((w) => (w.distance_km ?? 0) > 0);
+
+  const longest = withDistance.reduce<RecordWorkout | null>(
+    (best, w) => (best == null || (w.distance_km ?? 0) > (best.distance_km ?? 0) ? w : best),
+    null,
+  );
+  if (longest) {
+    records.push({
+      key: "longest-distance",
+      label: "Longest workout",
+      value: fmt.distanceKm(longest.distance_km, 1),
+      detail: [workoutMeta(longest.activity_type).label, dateLabel(longest.start_time)]
+        .filter(Boolean)
+        .join(" · "),
+      icon: "Route",
+      accent: "text-chart-2",
+    });
+  }
+
+  // Pace is only comparable within foot sports — cycling would always "win".
+  const FOOT_SPORTS = new Set(["Running", "Walking", "Hiking", "TrailRunning"]);
+  const pacers = withDistance.filter(
+    (w) => FOOT_SPORTS.has(w.activity_type) && (w.distance_km ?? 0) >= 1 && (w.duration_min ?? 0) > 0,
+  );
+  const fastest = pacers.reduce<RecordWorkout | null>((best, w) => {
+    const pace = (w.duration_min as number) / (w.distance_km as number);
+    if (best == null) return w;
+    const bestPace = (best.duration_min as number) / (best.distance_km as number);
+    return pace < bestPace ? w : best;
+  }, null);
+  if (fastest) {
+    records.push({
+      key: "fastest-pace",
+      label: "Fastest pace",
+      value: fmt.pace(fastest.distance_km, fastest.duration_min),
+      detail: [workoutMeta(fastest.activity_type).label, dateLabel(fastest.start_time)]
+        .filter(Boolean)
+        .join(" · "),
+      icon: "Zap",
+      accent: "text-chart-3",
+    });
+  }
+
+  const biggestBurn = workouts.reduce<RecordWorkout | null>(
+    (best, w) => (best == null || (w.energy_kcal ?? 0) > (best.energy_kcal ?? 0) ? w : best),
+    null,
+  );
+  if (biggestBurn && (biggestBurn.energy_kcal ?? 0) > 0) {
+    records.push({
+      key: "biggest-burn",
+      label: "Biggest burn",
+      value: `${fmt.number(biggestBurn.energy_kcal)} kcal`,
+      detail: [workoutMeta(biggestBurn.activity_type).label, dateLabel(biggestBurn.start_time)]
+        .filter(Boolean)
+        .join(" · "),
+      icon: "Flame",
+      accent: "text-chart-4",
+    });
+  }
+
+  // --- Daily-peak records ---
+  const daily = (
+    top: DailyTop | null | undefined,
+    cfg: { key: string; label: string; icon: string; accent: string; format: (v: number) => string },
+  ) => {
+    if (top?.value == null) return;
+    records.push({
+      key: cfg.key,
+      label: cfg.label,
+      value: cfg.format(top.value),
+      detail: dateLabel(top.date),
+      icon: cfg.icon,
+      accent: cfg.accent,
+    });
+  };
+
+  daily(tops.steps, {
+    key: "most-steps",
+    label: "Most steps",
+    icon: "Footprints",
+    accent: "text-chart-1",
+    format: (v) => fmt.number(v),
+  });
+  daily(tops.active_energy, {
+    key: "most-active-energy",
+    label: "Most active energy",
+    icon: "Flame",
+    accent: "text-chart-3",
+    format: (v) => `${fmt.number(v)} kcal`,
+  });
+  daily(tops.exercise_min, {
+    key: "longest-exercise-day",
+    label: "Longest exercise day",
+    icon: "Timer",
+    accent: "text-chart-4",
+    format: (v) => fmt.duration(v),
+  });
+  daily(tops.vo2max, {
+    key: "peak-vo2max",
+    label: "Peak VO₂ Max",
+    icon: "Gauge",
+    accent: "text-chart-3",
+    format: (v) => `${v.toFixed(1)} ml/kg`,
+  });
+  daily(tops.sleep_min, {
+    key: "best-sleep",
+    label: "Longest sleep",
+    icon: "Moon",
+    accent: "text-chart-2",
+    format: (v) => fmt.duration(v),
+  });
+  daily(tops.flights_climbed, {
+    key: "most-flights",
+    label: "Most flights climbed",
+    icon: "TrendingUp",
+    accent: "text-chart-1",
+    format: (v) => fmt.number(v),
+  });
+
+  return records;
+}

--- a/lib/insights/engine.ts
+++ b/lib/insights/engine.ts
@@ -1,0 +1,256 @@
+import type { DailyMetric } from "@/lib/queries/metrics";
+
+export interface Insight {
+  id: string;
+  /** Plain-English headline. */
+  text: string;
+  /** Short category tag, e.g. "Sleep → Recovery". */
+  tag: string;
+  /** Pearson correlation coefficient (signed). */
+  r: number;
+  /** Number of aligned day-pairs the correlation was computed over. */
+  n: number;
+  /** Is this a favourable relationship for the user? Drives icon/colour. */
+  sentiment: "positive" | "negative";
+  /** Tailwind text-colour token for the accent. */
+  accent: string;
+}
+
+type MetricKey = keyof DailyMetric;
+
+interface Rule {
+  id: string;
+  driver: MetricKey;
+  outcome: MetricKey;
+  /** Days the outcome trails the driver. 0 = same day, 1 = next day. */
+  lag: number;
+  tag: string;
+  accent: string;
+  /** Sign of correlation that is healthy/desirable for this pairing. */
+  desirable: "positive" | "negative";
+  /**
+   * Builds the sentence. `diff` is (high-driver-group mean − low-driver-group
+   * mean) for the outcome, already rounded; `dir` says whether the outcome rose
+   * or fell on high-driver days.
+   */
+  phrase: (diff: number, dir: "higher" | "lower") => string;
+}
+
+const MIN_N = 20;
+const MIN_ABS_R = 0.2;
+
+/** Pearson correlation over paired samples; null if degenerate. */
+export function pearson(xs: number[], ys: number[]): number | null {
+  const n = xs.length;
+  if (n < 3) return null;
+  let sx = 0;
+  let sy = 0;
+  for (let i = 0; i < n; i++) {
+    sx += xs[i];
+    sy += ys[i];
+  }
+  const mx = sx / n;
+  const my = sy / n;
+  let num = 0;
+  let dx2 = 0;
+  let dy2 = 0;
+  for (let i = 0; i < n; i++) {
+    const dx = xs[i] - mx;
+    const dy = ys[i] - my;
+    num += dx * dy;
+    dx2 += dx * dx;
+    dy2 += dy * dy;
+  }
+  const denom = Math.sqrt(dx2 * dy2);
+  if (denom === 0) return null;
+  return num / denom;
+}
+
+/** Mean of the outcome among the top vs bottom tertile of the driver. */
+function tertileSplit(pairs: Array<[number, number]>): { high: number; low: number } | null {
+  if (pairs.length < 6) return null;
+  const sorted = [...pairs].sort((a, b) => a[0] - b[0]);
+  const cut = Math.floor(sorted.length / 3);
+  if (cut === 0) return null;
+  const low = sorted.slice(0, cut);
+  const high = sorted.slice(-cut);
+  const mean = (rows: Array<[number, number]>) => rows.reduce((s, r) => s + r[1], 0) / rows.length;
+  return { high: mean(high), low: mean(low) };
+}
+
+const RULES: Rule[] = [
+  {
+    id: "sleep-rhr",
+    driver: "sleep_min",
+    outcome: "resting_hr",
+    lag: 1,
+    tag: "Sleep → Recovery",
+    accent: "text-chart-4",
+    desirable: "negative",
+    phrase: (d, dir) => `After your longest nights of sleep, next-day resting HR runs ${d} bpm ${dir}.`,
+  },
+  {
+    id: "sleep-hrv",
+    driver: "sleep_min",
+    outcome: "hrv_ms",
+    lag: 1,
+    tag: "Sleep → Recovery",
+    accent: "text-chart-1",
+    desirable: "positive",
+    phrase: (d, dir) => `More sleep nudges your next-day HRV ${d} ms ${dir}.`,
+  },
+  {
+    id: "exercise-rhr",
+    driver: "exercise_min",
+    outcome: "resting_hr",
+    lag: 1,
+    tag: "Training → Recovery",
+    accent: "text-chart-4",
+    desirable: "negative",
+    phrase: (d, dir) => `Your hardest training days are followed by a resting HR ${d} bpm ${dir}.`,
+  },
+  {
+    id: "exercise-hrv",
+    driver: "exercise_min",
+    outcome: "hrv_ms",
+    lag: 1,
+    tag: "Training → Recovery",
+    accent: "text-chart-1",
+    desirable: "positive",
+    phrase: (d, dir) => `Big exercise days shift next-day HRV ${d} ms ${dir}.`,
+  },
+  {
+    id: "steps-sleep",
+    driver: "steps",
+    outcome: "sleep_min",
+    lag: 0,
+    tag: "Activity → Sleep",
+    accent: "text-chart-2",
+    desirable: "positive",
+    phrase: (d, dir) => `On your most active days you sleep ${formatMinDiff(d)} ${dir === "higher" ? "longer" : "less"}.`,
+  },
+  {
+    id: "caffeine-sleep",
+    driver: "caffeine_mg",
+    outcome: "sleep_min",
+    lag: 0,
+    tag: "Nutrition → Sleep",
+    accent: "text-chart-3",
+    desirable: "negative",
+    phrase: (d, dir) => `Higher-caffeine days come with ${formatMinDiff(d)} ${dir === "higher" ? "more" : "less"} sleep.`,
+  },
+  {
+    id: "daylight-sleep",
+    driver: "daylight_min",
+    outcome: "sleep_min",
+    lag: 0,
+    tag: "Daylight → Sleep",
+    accent: "text-chart-2",
+    desirable: "positive",
+    phrase: (d, dir) => `More time in daylight tracks with ${formatMinDiff(d)} ${dir === "higher" ? "more" : "less"} sleep that night.`,
+  },
+  {
+    id: "active-energy-hrv",
+    driver: "active_energy",
+    outcome: "hrv_ms",
+    lag: 1,
+    tag: "Training → Recovery",
+    accent: "text-chart-1",
+    desirable: "positive",
+    phrase: (d, dir) => `Days you burn the most energy move next-day HRV ${d} ms ${dir}.`,
+  },
+  {
+    id: "sleep-quality-rhr",
+    driver: "sleep_quality",
+    outcome: "resting_hr",
+    lag: 1,
+    tag: "Sleep → Recovery",
+    accent: "text-chart-4",
+    desirable: "negative",
+    phrase: (d, dir) => `Better sleep quality is followed by a resting HR ${d} bpm ${dir}.`,
+  },
+  {
+    id: "respiratory-sleep",
+    driver: "respiratory_rate",
+    outcome: "sleep_quality",
+    lag: 0,
+    tag: "Vitals → Sleep",
+    accent: "text-chart-2",
+    desirable: "negative",
+    phrase: (d, dir) => `Nights with a higher respiratory rate score ${Math.abs(d)} pts ${dir} on sleep quality.`,
+  },
+];
+
+function formatMinDiff(minutes: number): string {
+  const m = Math.abs(Math.round(minutes));
+  if (m >= 60) {
+    const h = Math.floor(m / 60);
+    const rem = m % 60;
+    return rem ? `${h}h ${rem}m` : `${h}h`;
+  }
+  return `${m} min`;
+}
+
+/**
+ * Derive plain-English insights from a chronological run of daily metrics.
+ * Each rule correlates a driver metric against an outcome (optionally lagged a
+ * day) and, when the relationship is strong and well-sampled enough, emits a
+ * sentence quantifying the effect (high-driver vs low-driver day means).
+ */
+export function deriveInsights(metrics: DailyMetric[]): Insight[] {
+  // Index by date for O(1) lag lookups.
+  const byDate = new Map<string, DailyMetric>();
+  for (const row of metrics) if (row.date) byDate.set(row.date, row);
+
+  const dayMs = 864e5;
+  const shift = (date: string, lag: number) =>
+    new Date(new Date(`${date}T12:00:00`).getTime() + lag * dayMs).toISOString().slice(0, 10);
+
+  const insights: Insight[] = [];
+
+  for (const rule of RULES) {
+    const pairs: Array<[number, number]> = [];
+    for (const row of metrics) {
+      if (!row.date) continue;
+      const dv = row[rule.driver];
+      if (dv == null) continue;
+      const target = rule.lag === 0 ? row : byDate.get(shift(row.date, rule.lag));
+      const ov = target?.[rule.outcome];
+      if (ov == null) continue;
+      pairs.push([dv as number, ov as number]);
+    }
+
+    if (pairs.length < MIN_N) continue;
+    const r = pearson(
+      pairs.map((p) => p[0]),
+      pairs.map((p) => p[1]),
+    );
+    if (r == null || Math.abs(r) < MIN_ABS_R) continue;
+
+    const split = tertileSplit(pairs);
+    if (!split) continue;
+    const rawDiff = split.high - split.low;
+    if (rawDiff === 0) continue;
+
+    const dir: "higher" | "lower" = rawDiff > 0 ? "higher" : "lower";
+    const observedSign = r >= 0 ? "positive" : "negative";
+    const sentiment = observedSign === rule.desirable ? "positive" : "negative";
+
+    // Round the effect for display; HRV/HR/quality in integers, minutes raw.
+    const diff = Math.round(Math.abs(rawDiff));
+    if (diff === 0) continue;
+
+    insights.push({
+      id: rule.id,
+      text: rule.phrase(diff, dir),
+      tag: rule.tag,
+      r,
+      n: pairs.length,
+      sentiment,
+      accent: rule.accent,
+    });
+  }
+
+  // Strongest relationships first.
+  return insights.sort((a, b) => Math.abs(b.r) - Math.abs(a.r));
+}

--- a/lib/queries/all-routes.ts
+++ b/lib/queries/all-routes.ts
@@ -1,0 +1,55 @@
+import { useQuery } from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+import { queryKeys } from "./keys";
+
+export interface RouteRow {
+  id: string;
+  workout_id: string | null;
+  distance_km: number | null;
+  bounds: unknown;
+  points: unknown;
+}
+
+export interface RouteWorkout {
+  id: string;
+  activity_type: string;
+  start_time: string;
+}
+
+export interface AllRoutesData {
+  routes: RouteRow[];
+  workouts: RouteWorkout[];
+}
+
+/** Every GPS route plus the minimal workout metadata needed to filter them. */
+export function useAllRoutes() {
+  return useQuery({
+    queryKey: queryKeys.allRoutes,
+    // Routes are immutable between ingests and the payload is large — cache hard.
+    staleTime: 1000 * 60 * 30,
+    queryFn: async (): Promise<AllRoutesData> => {
+      const supabase = createClient();
+
+      const { data: routes, error } = await supabase
+        .from("workout_routes")
+        .select("id, workout_id, distance_km, bounds, points");
+      if (error) throw error;
+
+      // Page through workouts (>1000) for the activity type / date of each route.
+      const workouts: RouteWorkout[] = [];
+      for (let from = 0; ; from += 1000) {
+        const { data, error: e } = await supabase
+          .from("workouts")
+          .select("id, activity_type, start_time")
+          .order("start_time", { ascending: true })
+          .range(from, from + 999);
+        if (e) throw e;
+        const rows = (data ?? []) as RouteWorkout[];
+        workouts.push(...rows);
+        if (rows.length < 1000) break;
+      }
+
+      return { routes: (routes ?? []) as RouteRow[], workouts };
+    },
+  });
+}

--- a/lib/queries/keys.ts
+++ b/lib/queries/keys.ts
@@ -12,4 +12,6 @@ export const queryKeys = {
   sleep: (range: RangeKey) => ["sleep", range] as const,
   ecgList: ["ecg-list"] as const,
   ecg: (id: string) => ["ecg", id] as const,
+  records: ["records"] as const,
+  allRoutes: ["all-routes"] as const,
 };

--- a/lib/queries/profile.ts
+++ b/lib/queries/profile.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+import type { Tables } from "@/lib/supabase/database.types";
+import { queryKeys } from "./keys";
+
+export type Profile = Tables<"profile">;
+
+export function useProfile() {
+  return useQuery({
+    queryKey: queryKeys.profile,
+    queryFn: async (): Promise<Profile | null> => {
+      const supabase = createClient();
+      const { data, error } = await supabase.from("profile").select("*").limit(1).maybeSingle();
+      if (error) throw error;
+      return data;
+    },
+  });
+}

--- a/lib/queries/records.ts
+++ b/lib/queries/records.ts
@@ -1,0 +1,64 @@
+import { useQuery } from "@tanstack/react-query";
+import { createClient } from "@/lib/supabase/client";
+import type { Tables } from "@/lib/supabase/database.types";
+import { queryKeys } from "./keys";
+
+export type RecordWorkoutRow = Pick<
+  Tables<"workouts">,
+  "activity_type" | "distance_km" | "duration_min" | "energy_kcal" | "start_time"
+>;
+export type RecordDailyRow = Pick<
+  Tables<"daily_metrics">,
+  "date" | "steps" | "active_energy" | "exercise_min" | "vo2max" | "sleep_min" | "flights_climbed" | "resting_hr"
+>;
+
+export interface RecordsData {
+  workouts: RecordWorkoutRow[];
+  daily: RecordDailyRow[];
+}
+
+const PAGE = 1000;
+
+/** Page through a table beyond PostgREST's 1000-row cap so records are exact. */
+async function fetchAll<T>(
+  table: "workouts" | "daily_metrics",
+  columns: string,
+  orderCol: string,
+): Promise<T[]> {
+  const supabase = createClient();
+  const out: T[] = [];
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await supabase
+      .from(table)
+      .select(columns)
+      .order(orderCol, { ascending: true })
+      .range(from, from + PAGE - 1);
+    if (error) throw error;
+    const rows = (data ?? []) as unknown as T[];
+    out.push(...rows);
+    if (rows.length < PAGE) break;
+  }
+  return out;
+}
+
+/** All workouts + daily metrics (minimal columns) for personal-record analysis. */
+export function useRecords() {
+  return useQuery({
+    queryKey: queryKeys.records,
+    queryFn: async (): Promise<RecordsData> => {
+      const [workouts, daily] = await Promise.all([
+        fetchAll<RecordWorkoutRow>(
+          "workouts",
+          "activity_type, distance_km, duration_min, energy_kcal, start_time",
+          "start_time",
+        ),
+        fetchAll<RecordDailyRow>(
+          "daily_metrics",
+          "date, steps, active_energy, exercise_min, vo2max, sleep_min, flights_climbed, resting_hr",
+          "date",
+        ),
+      ]);
+      return { workouts, daily };
+    },
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     globals: true,
     setupFiles: ["./vitest.setup.ts"],
     include: ["**/*.{test,spec}.{ts,tsx}"],
-    exclude: ["node_modules", ".next"],
+    exclude: ["node_modules", ".next", ".claude"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Four creative, data-driven features that surface much more of the Apple Health export. Everything reads from data we already ingest — no schema changes.

## 🧠 Insights engine
- Correlates a year of daily metrics (with day lags) into plain-English findings, e.g. *"Nights with a higher respiratory rate score lower on sleep quality."*
- Pearson correlation + tertile high/low effect sizing; only relationships with |r| ≥ 0.2 over ≥ 20 days are shown.
- New `/insights` page + an **Overview** card (top 3).

## 💪 Readiness score
- Oura/Whoop-style daily **0–100** from HRV and resting HR vs each person's *rolling 60-day baseline*, sleep vs an 8h target, and prior-day training load.
- Animated radial gauge + contributor breakdown + 30-day trend, on **Overview** and the **Heart** page.

## 🎂 Fitness age + 🏆 personal records
- VO₂ Max / resting-HR ratings vs **age + sex norms** (from `profile` DOB/sex) → a "fitness age".
- Personal-records wall: longest workout, fastest pace (foot sports only — pace isn't comparable to cycling), biggest burn, most steps, longest sleep, peak VO₂ Max, etc.
- New `/records` page.

## 🗺️ Routes territory map
- Overlays **all 522 GPS routes** on one MapLibre map (free OSM tiles), semi-transparent for a heat effect, filterable by **sport / year** with route/distance/sport stats.
- Routes downsampled client-side for performance; MapLibre is code-split into the `/map` chunk.

## Quality
- Pure logic is unit-tested: **+31 tests** (insights, readiness, fitness/records) — suite now 66 passing.
- `records` / `all-routes` queries **paginate past PostgREST's 1000-row cap** so bests are exact across all history.
- Nav gains Insights, Routes Map and Records. `vitest` now excludes `.claude` worktrees.
- ✅ typecheck · ✅ lint · ✅ 66 tests · ✅ production build (15 routes) · verified on desktop + mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)