### PR TITLE
feat(workouts): filters, pagination, map indicators, green theme, configurable chart

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -31,6 +31,9 @@
   --chart-3: oklch(0.646 0.222 41.116); /* orange — workouts   */
   --chart-4: oklch(0.577 0.245 27.325); /* red    — heart      */
   --chart-5: oklch(0.488 0.243 264.376); /* indigo — body       */
+
+  /* Apple Fitness "Exercise" ring green — the Workouts domain accent */
+  --workout: oklch(0.77 0.205 134);
 }
 
 .dark {
@@ -58,6 +61,8 @@
   --chart-3: oklch(0.769 0.188 70.08); /* orange */
   --chart-4: oklch(0.704 0.191 22.216); /* red    */
   --chart-5: oklch(0.627 0.265 303.9); /* violet */
+
+  --workout: oklch(0.845 0.222 132); /* Apple exercise green */
 }
 
 @theme inline {
@@ -84,6 +89,7 @@
   --color-chart-3: var(--chart-3);
   --color-chart-4: var(--chart-4);
   --color-chart-5: var(--chart-5);
+  --color-workout: var(--workout);
 
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);

--- a/app/workouts/page.tsx
+++ b/app/workouts/page.tsx
@@ -1,23 +1,45 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
-import { Dumbbell, Flame, Route, Timer } from "lucide-react";
-import { useWorkouts } from "@/lib/queries/workouts";
+import {
+  ChevronDown,
+  Dumbbell,
+  Filter,
+  Flame,
+  HeartPulse,
+  MapPin,
+  Route,
+  Timer,
+  X,
+} from "lucide-react";
+import { useWorkouts, useWorkoutRouteIds } from "@/lib/queries/workouts";
 import { PageHeader } from "@/components/dashboard/page-header";
-import { RangeSelect } from "@/components/dashboard/range-select";
+import { DateRangeSelect, isCustomRangeActive, type CustomRange } from "@/components/dashboard/date-range-select";
 import { StatCard } from "@/components/dashboard/stat-card";
-import { TrendChart } from "@/components/charts/trend-chart";
+import { TablePagination } from "@/components/dashboard/table-pagination";
+import {
+  EMPTY_RANGE,
+  isRangeActive,
+  matchesRange,
+  NumberRangeFilter,
+  type NumberRange,
+} from "@/components/dashboard/number-range-filter";
+import {
+  ConfigurableTrendChart,
+  type ChartMetric,
+} from "@/components/charts/configurable-trend-chart";
 import { CardGridSkeleton, ChartSkeleton, QueryView } from "@/components/dashboard/states";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import {
   Table,
   TableBody,
@@ -28,7 +50,7 @@ import {
 } from "@/components/ui/table";
 import type { RangeKey } from "@/lib/queries/ranges";
 import * as fmt from "@/lib/format";
-import { sum } from "@/lib/stats";
+import { deltaPct, sum } from "@/lib/stats";
 import {
   CATEGORY_ACCENT,
   CATEGORY_LABELS,
@@ -38,29 +60,175 @@ import {
 import { WorkoutIcon } from "@/components/dashboard/workout-icon";
 import { cn } from "@/lib/utils";
 
-type CategoryFilter = WorkoutCategory | "all";
+const WORKOUT_GREEN = "var(--workout)";
+
+/** Trend over the range: last half vs first half of the daily series. */
+function trendDelta(values: Array<number | null>): number | null {
+  const window = Math.floor(values.length / 2);
+  if (window < 1) return null;
+  return deltaPct(values, window, sum);
+}
 
 export default function WorkoutsPage() {
   const [range, setRange] = useState<RangeKey>("90d");
-  const [category, setCategory] = useState<CategoryFilter>("all");
-  const query = useWorkouts({ range });
+  const [custom, setCustom] = useState<CustomRange | null>(null);
+
+  // Stackable filters
+  const [categories, setCategories] = useState<Set<WorkoutCategory>>(new Set());
+  const [mapOnly, setMapOnly] = useState(false);
+  const [duration, setDuration] = useState<NumberRange>(EMPTY_RANGE);
+  const [distance, setDistance] = useState<NumberRange>(EMPTY_RANGE);
+  const [calories, setCalories] = useState<NumberRange>(EMPTY_RANGE);
+  const [avgHr, setAvgHr] = useState<NumberRange>(EMPTY_RANGE);
+
+  // Pagination
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(25);
+
+  const customActive = isCustomRangeActive(custom);
+  const from = customActive && custom?.from ? `${custom.from}T00:00:00` : undefined;
+  const until = customActive && custom?.to ? `${custom.to}T23:59:59` : undefined;
+
+  const query = useWorkouts({ range: customActive ? "all" : range, from, until });
+  const routeIdsQuery = useWorkoutRouteIds();
+  const routeIdsData = routeIdsQuery.data;
+  const routeIds = useMemo(() => routeIdsData ?? new Set<string>(), [routeIdsData]);
+
+  const toggleCategory = (c: WorkoutCategory) =>
+    setCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(c)) next.delete(c);
+      else next.add(c);
+      return next;
+    });
+
+  const anyFilterActive =
+    categories.size > 0 ||
+    mapOnly ||
+    isRangeActive(duration) ||
+    isRangeActive(distance) ||
+    isRangeActive(calories) ||
+    isRangeActive(avgHr);
+
+  const clearFilters = () => {
+    setCategories(new Set());
+    setMapOnly(false);
+    setDuration(EMPTY_RANGE);
+    setDistance(EMPTY_RANGE);
+    setCalories(EMPTY_RANGE);
+    setAvgHr(EMPTY_RANGE);
+  };
 
   const filtered = useMemo(() => {
-    const rows = query.data ?? [];
-    if (category === "all") return rows;
-    return rows.filter((w) => workoutMeta(w.activity_type).category === category);
-  }, [query.data, category]);
+    let rows = query.data ?? [];
+    if (categories.size)
+      rows = rows.filter((w) => categories.has(workoutMeta(w.activity_type).category));
+    if (mapOnly) rows = rows.filter((w) => routeIds.has(w.id));
+    if (isRangeActive(duration)) rows = rows.filter((w) => matchesRange(w.duration_min, duration));
+    if (isRangeActive(distance)) rows = rows.filter((w) => matchesRange(w.distance_km, distance));
+    if (isRangeActive(calories)) rows = rows.filter((w) => matchesRange(w.energy_kcal, calories));
+    if (isRangeActive(avgHr)) rows = rows.filter((w) => matchesRange(w.avg_heart_rate, avgHr));
+    return rows;
+  }, [query.data, categories, mapOnly, duration, distance, calories, avgHr, routeIds]);
 
-  const caloriesByDay = useMemo(() => {
-    const map = new Map<string, number>();
+  // Reset to the first page whenever the result set changes.
+  const filterKey = `${range}|${customActive}|${custom?.from}|${custom?.to}|${[...categories].sort().join(",")}|${mapOnly}|${duration.min}-${duration.max}|${distance.min}-${distance.max}|${calories.min}-${calories.max}|${avgHr.min}-${avgHr.max}`;
+  useEffect(() => {
+    setPage(0);
+  }, [filterKey]);
+
+  // Daily aggregates power both the stat-card sparklines and the main chart.
+  const daily = useMemo(() => {
+    const map = new Map<
+      string,
+      { kcal: number; km: number; min: number; count: number; hrSum: number; hrCount: number }
+    >();
     for (const w of filtered) {
       const d = w.start_time.slice(0, 10);
-      map.set(d, (map.get(d) ?? 0) + (w.energy_kcal ?? 0));
+      const e =
+        map.get(d) ?? { kcal: 0, km: 0, min: 0, count: 0, hrSum: 0, hrCount: 0 };
+      e.kcal += w.energy_kcal ?? 0;
+      e.km += w.distance_km ?? 0;
+      e.min += w.duration_min ?? 0;
+      e.count += 1;
+      if (w.avg_heart_rate != null) {
+        e.hrSum += w.avg_heart_rate;
+        e.hrCount += 1;
+      }
+      map.set(d, e);
     }
     return Array.from(map.entries())
-      .map(([date, kcal]) => ({ date, kcal }))
+      .map(([date, v]) => ({
+        date,
+        calories: v.kcal,
+        distance: v.km,
+        duration: v.min,
+        sessions: v.count,
+        avgHr: v.hrCount ? v.hrSum / v.hrCount : null,
+      }))
       .sort((a, b) => a.date.localeCompare(b.date));
   }, [filtered]);
+
+  // Totals + secondary stats for the tiles
+  const sessions = filtered.length;
+  const totalKcal = sum(filtered.map((w) => w.energy_kcal));
+  const totalKm = sum(filtered.map((w) => w.distance_km));
+  const totalMin = sum(filtered.map((w) => w.duration_min));
+  const distanceSessions = filtered.filter((w) => w.distance_km != null && w.distance_km > 0).length;
+
+  const chartMetrics: ChartMetric[] = useMemo(
+    () => [
+      {
+        key: "calories",
+        label: "Calories",
+        icon: Flame,
+        unit: "kcal",
+        color: WORKOUT_GREEN,
+        data: daily.map((d) => ({ date: d.date, value: d.calories })),
+        valueFormatter: (v) => fmt.compactNumber(v),
+      },
+      {
+        key: "distance",
+        label: "Distance",
+        icon: Route,
+        unit: "km",
+        color: WORKOUT_GREEN,
+        data: daily.map((d) => ({ date: d.date, value: d.distance })),
+        valueFormatter: (v) => fmt.number(v, v >= 100 ? 0 : 1),
+      },
+      {
+        key: "duration",
+        label: "Duration",
+        icon: Timer,
+        unit: "min",
+        color: WORKOUT_GREEN,
+        data: daily.map((d) => ({ date: d.date, value: d.duration })),
+        valueFormatter: (v) => fmt.number(v, 0),
+      },
+      {
+        key: "sessions",
+        label: "Sessions",
+        icon: Dumbbell,
+        color: WORKOUT_GREEN,
+        data: daily.map((d) => ({ date: d.date, value: d.sessions })),
+        valueFormatter: (v) => fmt.number(v, 0),
+      },
+      {
+        key: "avgHr",
+        label: "Avg heart rate",
+        icon: HeartPulse,
+        unit: "bpm",
+        color: "var(--chart-4)",
+        data: daily.map((d) => ({ date: d.date, value: d.avgHr })),
+        valueFormatter: (v) => fmt.number(v, 0),
+      },
+    ],
+    [daily],
+  );
+
+  const pageCount = Math.max(1, Math.ceil(filtered.length / pageSize));
+  const safePage = Math.min(page, pageCount - 1);
+  const pageRows = filtered.slice(safePage * pageSize, safePage * pageSize + pageSize);
 
   return (
     <>
@@ -68,22 +236,12 @@ export default function WorkoutsPage() {
         title="Workouts"
         description="Every session — cardio, strength and beyond — with maps and metrics."
         actions={
-          <div className="flex items-center gap-2">
-            <Select value={category} onValueChange={(v) => setCategory(v as CategoryFilter)}>
-              <SelectTrigger className="w-[140px]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="all">All types</SelectItem>
-                {(Object.keys(CATEGORY_LABELS) as WorkoutCategory[]).map((c) => (
-                  <SelectItem key={c} value={c}>
-                    {CATEGORY_LABELS[c]}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-            <RangeSelect value={range} onChange={setRange} />
-          </div>
+          <DateRangeSelect
+            range={range}
+            onRangeChange={setRange}
+            custom={custom}
+            onCustomChange={setCustom}
+          />
         }
       />
 
@@ -95,29 +253,122 @@ export default function WorkoutsPage() {
             <ChartSkeleton />
           </div>
         }
-        isEmpty={() => filtered.length === 0}
+        isEmpty={(rows) => rows.length === 0}
       >
         {() => (
           <div className="space-y-6">
             <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-              <StatCard label="Sessions" value={fmt.number(filtered.length)} icon={Dumbbell} accent="text-chart-3" />
-              <StatCard label="Calories burned" value={fmt.number(sum(filtered.map((w) => w.energy_kcal)))} unit="kcal" icon={Flame} accent="text-chart-4" />
-              <StatCard label="Total distance" value={fmt.number(sum(filtered.map((w) => w.distance_km)))} unit="km" icon={Route} accent="text-chart-2" />
-              <StatCard label="Time" value={fmt.duration(sum(filtered.map((w) => w.duration_min)))} icon={Timer} accent="text-chart-1" />
+              <StatCard
+                label="Sessions"
+                value={fmt.number(sessions)}
+                icon={Dumbbell}
+                accent="text-workout"
+                delta={trendDelta(daily.map((d) => d.sessions))}
+                sub={`${fmt.number(daily.length)} active ${daily.length === 1 ? "day" : "days"}`}
+                spark={{ data: daily, dataKey: "sessions", color: WORKOUT_GREEN }}
+              />
+              <StatCard
+                label="Calories burned"
+                value={fmt.number(totalKcal)}
+                unit="kcal"
+                icon={Flame}
+                accent="text-workout"
+                delta={trendDelta(daily.map((d) => d.calories))}
+                sub={sessions ? `${fmt.number(totalKcal / sessions)} avg/session` : undefined}
+                spark={{ data: daily, dataKey: "calories", color: WORKOUT_GREEN }}
+              />
+              <StatCard
+                label="Total distance"
+                value={fmt.number(totalKm)}
+                unit="km"
+                icon={Route}
+                accent="text-workout"
+                delta={trendDelta(daily.map((d) => d.distance))}
+                sub={
+                  distanceSessions
+                    ? `${fmt.distanceKm(totalKm / distanceSessions)} avg`
+                    : "no distance logged"
+                }
+                spark={{ data: daily, dataKey: "distance", color: WORKOUT_GREEN }}
+              />
+              <StatCard
+                label="Time"
+                value={fmt.duration(totalMin)}
+                icon={Timer}
+                accent="text-workout"
+                delta={trendDelta(daily.map((d) => d.duration))}
+                sub={sessions ? `${fmt.duration(totalMin / sessions)} avg/session` : undefined}
+                spark={{ data: daily, dataKey: "duration", color: WORKOUT_GREEN }}
+              />
             </div>
 
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-base">Calories burned</CardTitle>
-              </CardHeader>
-              <CardContent>
-                <TrendChart data={caloriesByDay} series={[{ key: "kcal", label: "Calories", type: "bar", color: "var(--chart-3)" }]} />
-              </CardContent>
-            </Card>
+            <ConfigurableTrendChart
+              title="Trends over time"
+              metrics={chartMetrics}
+              defaultMetric="calories"
+              defaultType="bar"
+            />
 
             <Card>
-              <CardHeader>
+              <CardHeader className="gap-3">
                 <CardTitle className="text-base">Sessions</CardTitle>
+                <div className="flex flex-wrap items-center gap-2">
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        className={cn("gap-1.5", categories.size > 0 && "border-workout text-workout")}
+                      >
+                        <Filter className="h-3.5 w-3.5" /> Type
+                        {categories.size > 0 && (
+                          <Badge variant="secondary" className="ml-0.5 h-4 px-1 text-[10px]">
+                            {categories.size}
+                          </Badge>
+                        )}
+                        <ChevronDown className="h-3.5 w-3.5 opacity-60" />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="start" className="w-44">
+                      <DropdownMenuLabel>Activity type</DropdownMenuLabel>
+                      {(Object.keys(CATEGORY_LABELS) as WorkoutCategory[]).map((c) => (
+                        <DropdownMenuCheckboxItem
+                          key={c}
+                          checked={categories.has(c)}
+                          onCheckedChange={() => toggleCategory(c)}
+                          onSelect={(e) => e.preventDefault()}
+                        >
+                          {CATEGORY_LABELS[c]}
+                        </DropdownMenuCheckboxItem>
+                      ))}
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+
+                  <NumberRangeFilter label="Duration" unit="min" value={duration} onChange={setDuration} />
+                  <NumberRangeFilter label="Distance" unit="km" value={distance} onChange={setDistance} />
+                  <NumberRangeFilter label="Calories" unit="kcal" value={calories} onChange={setCalories} />
+                  <NumberRangeFilter label="Avg HR" unit="bpm" value={avgHr} onChange={setAvgHr} />
+
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className={cn("gap-1.5", mapOnly && "border-workout bg-workout/10 text-workout")}
+                    onClick={() => setMapOnly((v) => !v)}
+                  >
+                    <MapPin className="h-3.5 w-3.5" /> Has map
+                  </Button>
+
+                  {anyFilterActive && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="gap-1.5 text-muted-foreground"
+                      onClick={clearFilters}
+                    >
+                      <X className="h-3.5 w-3.5" /> Clear
+                    </Button>
+                  )}
+                </div>
               </CardHeader>
               <CardContent className="px-0">
                 <Table>
@@ -133,32 +384,62 @@ export default function WorkoutsPage() {
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {filtered.slice(0, 100).map((w) => {
-                      const meta = workoutMeta(w.activity_type);
-                      return (
-                        <TableRow key={w.id} className="cursor-pointer">
-                          <TableCell className="pl-6">
-                            <Link href={`/workouts/${w.id}`} className="flex items-center gap-2.5 font-medium hover:underline">
-                              <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted">
-                                <WorkoutIcon name={meta.icon} className={cn("h-4 w-4", CATEGORY_ACCENT[meta.category])} />
-                              </span>
-                              {meta.label}
-                              <Badge variant="secondary" className="text-[10px]">
-                                {CATEGORY_LABELS[meta.category]}
-                              </Badge>
-                            </Link>
-                          </TableCell>
-                          <TableCell className="text-muted-foreground">{fmt.shortDate(w.start_time)}</TableCell>
-                          <TableCell className="text-right tabular-nums">{fmt.duration(w.duration_min)}</TableCell>
-                          <TableCell className="text-right tabular-nums">{w.distance_km ? fmt.distanceKm(w.distance_km) : "—"}</TableCell>
-                          <TableCell className="text-right tabular-nums">{fmt.number(w.energy_kcal)}</TableCell>
-                          <TableCell className="text-right tabular-nums">{w.avg_heart_rate ? fmt.number(w.avg_heart_rate) : "—"}</TableCell>
-                          <TableCell className="pr-6 text-right tabular-nums">{fmt.pace(w.distance_km, w.duration_min)}</TableCell>
-                        </TableRow>
-                      );
-                    })}
+                    {pageRows.length === 0 ? (
+                      <TableRow>
+                        <TableCell colSpan={7} className="h-32 text-center text-muted-foreground">
+                          No sessions match the current filters.
+                        </TableCell>
+                      </TableRow>
+                    ) : (
+                      pageRows.map((w) => {
+                        const meta = workoutMeta(w.activity_type);
+                        const hasMap = routeIds.has(w.id);
+                        return (
+                          <TableRow key={w.id} className="cursor-pointer">
+                            <TableCell className="pl-6">
+                              <Link
+                                href={`/workouts/${w.id}`}
+                                className="flex items-center gap-2.5 font-medium hover:underline"
+                              >
+                                <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-muted">
+                                  <WorkoutIcon
+                                    name={meta.icon}
+                                    className={cn("h-4 w-4", CATEGORY_ACCENT[meta.category])}
+                                  />
+                                </span>
+                                {meta.label}
+                                <Badge variant="secondary" className="text-[10px]">
+                                  {CATEGORY_LABELS[meta.category]}
+                                </Badge>
+                                {hasMap && (
+                                  <span title="Route map available" className="inline-flex">
+                                    <MapPin className="h-3.5 w-3.5 text-workout" aria-label="Route map available" />
+                                  </span>
+                                )}
+                              </Link>
+                            </TableCell>
+                            <TableCell className="text-muted-foreground">{fmt.shortDate(w.start_time)}</TableCell>
+                            <TableCell className="text-right tabular-nums">{fmt.duration(w.duration_min)}</TableCell>
+                            <TableCell className="text-right tabular-nums">{w.distance_km ? fmt.distanceKm(w.distance_km) : "—"}</TableCell>
+                            <TableCell className="text-right tabular-nums">{fmt.number(w.energy_kcal)}</TableCell>
+                            <TableCell className="text-right tabular-nums">{w.avg_heart_rate ? fmt.number(w.avg_heart_rate) : "—"}</TableCell>
+                            <TableCell className="pr-6 text-right tabular-nums">{fmt.pace(w.distance_km, w.duration_min)}</TableCell>
+                          </TableRow>
+                        );
+                      })
+                    )}
                   </TableBody>
                 </Table>
+                <TablePagination
+                  page={safePage}
+                  pageSize={pageSize}
+                  total={filtered.length}
+                  onPageChange={setPage}
+                  onPageSizeChange={(size) => {
+                    setPageSize(size);
+                    setPage(0);
+                  }}
+                />
               </CardContent>
             </Card>
           </div>

--- a/components/charts/chart-type-toggle.tsx
+++ b/components/charts/chart-type-toggle.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { AreaChart, BarChart3, LineChart, type LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type ChartType = "bar" | "line" | "area";
+
+const OPTIONS: { type: ChartType; icon: LucideIcon; label: string }[] = [
+  { type: "bar", icon: BarChart3, label: "Bar" },
+  { type: "line", icon: LineChart, label: "Line" },
+  { type: "area", icon: AreaChart, label: "Area" },
+];
+
+/** Reusable segmented control for switching a chart between bar/line/area. */
+export function ChartTypeToggle({
+  value,
+  onChange,
+  className,
+}: {
+  value: ChartType;
+  onChange: (type: ChartType) => void;
+  className?: string;
+}) {
+  return (
+    <div className={cn("inline-flex items-center rounded-md border p-0.5", className)}>
+      {OPTIONS.map(({ type, icon: Icon, label }) => (
+        <button
+          key={type}
+          type="button"
+          aria-label={label}
+          aria-pressed={value === type}
+          title={label}
+          onClick={() => onChange(type)}
+          className={cn(
+            "inline-flex h-7 w-7 items-center justify-center rounded-[5px] text-muted-foreground transition-colors hover:text-foreground",
+            value === type && "bg-muted text-foreground",
+          )}
+        >
+          <Icon className="h-4 w-4" />
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/components/charts/configurable-trend-chart.tsx
+++ b/components/charts/configurable-trend-chart.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import type { LucideIcon } from "lucide-react";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { TrendChart } from "./trend-chart";
+import { ChartTypeToggle, type ChartType } from "./chart-type-toggle";
+
+export interface ChartMetric {
+  key: string;
+  label: string;
+  icon?: LucideIcon;
+  unit?: string;
+  /** CSS colour for the series; defaults to a chart token. */
+  color?: string;
+  data: Array<{ date: string; value: number | null }>;
+  valueFormatter?: (value: number) => string;
+}
+
+/**
+ * A chart card with a built-in metric selector (cycle through stats) and a
+ * bar/line/area type toggle. Reusable across pages — pass a list of metrics,
+ * each carrying its own pre-aggregated `{ date, value }[]` series.
+ */
+export function ConfigurableTrendChart({
+  metrics,
+  title,
+  defaultMetric,
+  defaultType = "bar",
+  height,
+}: {
+  metrics: ChartMetric[];
+  title?: string;
+  defaultMetric?: string;
+  defaultType?: ChartType;
+  height?: number;
+}) {
+  const [metricKey, setMetricKey] = useState(defaultMetric ?? metrics[0]?.key);
+  const [type, setType] = useState<ChartType>(defaultType);
+
+  const metric = metrics.find((m) => m.key === metricKey) ?? metrics[0];
+  const Icon = metric?.icon;
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between gap-3 space-y-0">
+        <div className="flex items-center gap-2.5">
+          {Icon && (
+            <span className="flex h-9 w-9 items-center justify-center rounded-md bg-muted">
+              <Icon className="h-5 w-5" style={{ color: metric?.color }} />
+            </span>
+          )}
+          <div className="space-y-0.5">
+            {title && <p className="text-xs text-muted-foreground">{title}</p>}
+            <p className="text-base font-semibold leading-none">
+              {metric?.label}
+              {metric?.unit ? (
+                <span className="ml-1 text-sm font-normal text-muted-foreground">{metric.unit}</span>
+              ) : null}
+            </p>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <Select value={metricKey} onValueChange={setMetricKey}>
+            <SelectTrigger className="w-[150px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {metrics.map((m) => (
+                <SelectItem key={m.key} value={m.key}>
+                  {m.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <ChartTypeToggle value={type} onChange={setType} />
+        </div>
+      </CardHeader>
+      <CardContent>
+        {metric && (
+          <TrendChart
+            data={metric.data}
+            series={[
+              {
+                key: "value",
+                label: metric.label,
+                type,
+                color: metric.color,
+                unit: metric.unit,
+              },
+            ]}
+            height={height}
+            valueFormatter={metric.valueFormatter}
+          />
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/dashboard/date-range-select.tsx
+++ b/components/dashboard/date-range-select.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { CalendarDays } from "lucide-react";
+import { format, parseISO } from "date-fns";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { RANGE_OPTIONS, type RangeKey } from "@/lib/queries/ranges";
+import { cn } from "@/lib/utils";
+
+export interface CustomRange {
+  /** yyyy-MM-dd */
+  from: string;
+  /** yyyy-MM-dd */
+  to: string;
+}
+
+export function isCustomRangeActive(custom: CustomRange | null): boolean {
+  return !!custom && (custom.from !== "" || custom.to !== "");
+}
+
+function fmtDay(iso: string): string {
+  try {
+    return format(parseISO(iso), "d MMM yyyy");
+  } catch {
+    return iso;
+  }
+}
+
+/**
+ * Date range control: preset windows (7d/30d/…/all) plus a custom from–to
+ * picker. When a custom range is active it takes precedence over the preset.
+ */
+export function DateRangeSelect({
+  range,
+  onRangeChange,
+  custom,
+  onCustomChange,
+}: {
+  range: RangeKey;
+  onRangeChange: (range: RangeKey) => void;
+  custom: CustomRange | null;
+  onCustomChange: (custom: CustomRange | null) => void;
+}) {
+  const isCustom = isCustomRangeActive(custom);
+  const label = isCustom
+    ? `${custom!.from ? fmtDay(custom!.from) : "…"} – ${custom!.to ? fmtDay(custom!.to) : "…"}`
+    : (RANGE_OPTIONS.find((o) => o.value === range)?.label ?? "Range");
+
+  const draft = custom ?? { from: "", to: "" };
+  const setDraft = (next: CustomRange) =>
+    onCustomChange(next.from === "" && next.to === "" ? null : next);
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="outline" className={cn("gap-2", isCustom && "border-workout text-workout")}>
+          <CalendarDays className="h-4 w-4" />
+          {label}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-64 space-y-3" align="end">
+        <div className="grid grid-cols-3 gap-1.5">
+          {RANGE_OPTIONS.map((opt) => (
+            <Button
+              key={opt.value}
+              variant={!isCustom && range === opt.value ? "default" : "outline"}
+              size="sm"
+              onClick={() => {
+                onCustomChange(null);
+                onRangeChange(opt.value);
+              }}
+            >
+              {opt.label}
+            </Button>
+          ))}
+        </div>
+
+        <div className="border-t pt-3">
+          <p className="mb-2 text-xs font-medium text-muted-foreground">Custom range</p>
+          <div className="flex items-center gap-2">
+            <input
+              type="date"
+              value={draft.from}
+              max={draft.to || undefined}
+              onChange={(e) => setDraft({ ...draft, from: e.target.value })}
+              className="h-8 w-full rounded-md border bg-background px-2 text-sm outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            />
+            <span className="text-muted-foreground">–</span>
+            <input
+              type="date"
+              value={draft.to}
+              min={draft.from || undefined}
+              onChange={(e) => setDraft({ ...draft, to: e.target.value })}
+              className="h-8 w-full rounded-md border bg-background px-2 text-sm outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+            />
+          </div>
+          {isCustom && (
+            <Button
+              variant="ghost"
+              size="xs"
+              className="mt-2 w-full"
+              onClick={() => onCustomChange(null)}
+            >
+              Clear custom range
+            </Button>
+          )}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/components/dashboard/nav.ts
+++ b/components/dashboard/nav.ts
@@ -21,7 +21,7 @@ export interface NavItem {
 
 export const NAV_ITEMS: NavItem[] = [
   { href: "/", label: "Overview", icon: LayoutDashboard, accent: "text-chart-1" },
-  { href: "/workouts", label: "Workouts", icon: Dumbbell, accent: "text-chart-3" },
+  { href: "/workouts", label: "Workouts", icon: Dumbbell, accent: "text-workout" },
   { href: "/activity", label: "Activity", icon: Activity, accent: "text-chart-1" },
   { href: "/heart", label: "Heart & Vitals", icon: HeartPulse, accent: "text-chart-4" },
   { href: "/sleep", label: "Sleep", icon: Moon, accent: "text-chart-2" },

--- a/components/dashboard/number-range-filter.tsx
+++ b/components/dashboard/number-range-filter.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { ChevronDown } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+
+export interface NumberRange {
+  min: string;
+  max: string;
+}
+
+export const EMPTY_RANGE: NumberRange = { min: "", max: "" };
+
+export function isRangeActive(range: NumberRange): boolean {
+  return range.min.trim() !== "" || range.max.trim() !== "";
+}
+
+/** Returns true when `value` falls inside the (optional) min/max bounds. */
+export function matchesRange(value: number | null | undefined, range: NumberRange): boolean {
+  const min = range.min.trim() === "" ? null : Number(range.min);
+  const max = range.max.trim() === "" ? null : Number(range.max);
+  if (min == null && max == null) return true;
+  if (value == null || Number.isNaN(value)) return false;
+  if (min != null && value < min) return false;
+  if (max != null && value > max) return false;
+  return true;
+}
+
+/** A reusable popover with min/max inputs for filtering a numeric column. */
+export function NumberRangeFilter({
+  label,
+  unit,
+  value,
+  onChange,
+}: {
+  label: string;
+  unit?: string;
+  value: NumberRange;
+  onChange: (range: NumberRange) => void;
+}) {
+  const active = isRangeActive(value);
+  const summary = active
+    ? `${value.min || "0"}–${value.max || "∞"}`
+    : null;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          size="sm"
+          className={cn("gap-1.5", active && "border-workout text-workout")}
+        >
+          {label}
+          {summary && <span className="tabular-nums">{summary}</span>}
+          <ChevronDown className="h-3.5 w-3.5 opacity-60" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-56 space-y-3" align="start">
+        <p className="text-xs font-medium text-muted-foreground">
+          {label}
+          {unit ? ` (${unit})` : ""}
+        </p>
+        <div className="flex items-center gap-2">
+          <input
+            type="number"
+            inputMode="decimal"
+            placeholder="Min"
+            value={value.min}
+            onChange={(e) => onChange({ ...value, min: e.target.value })}
+            className="h-8 w-full rounded-md border bg-background px-2 text-sm tabular-nums outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+          />
+          <span className="text-muted-foreground">–</span>
+          <input
+            type="number"
+            inputMode="decimal"
+            placeholder="Max"
+            value={value.max}
+            onChange={(e) => onChange({ ...value, max: e.target.value })}
+            className="h-8 w-full rounded-md border bg-background px-2 text-sm tabular-nums outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+          />
+        </div>
+        {active && (
+          <Button
+            variant="ghost"
+            size="xs"
+            className="w-full"
+            onClick={() => onChange(EMPTY_RANGE)}
+          >
+            Clear
+          </Button>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/components/dashboard/stat-card.tsx
+++ b/components/dashboard/stat-card.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type { LucideIcon } from "lucide-react";
 import { TrendingDown, TrendingUp } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -14,6 +15,8 @@ export interface StatCardProps {
   delta?: number | null;
   /** If true, a downward delta is the "good" direction (e.g. resting HR). */
   invertDelta?: boolean;
+  /** Secondary stat shown beneath the value, e.g. "520 avg/session". */
+  sub?: ReactNode;
   spark?: { data: Array<Record<string, number | null | string>>; dataKey: string; color?: string };
 }
 
@@ -25,6 +28,7 @@ export function StatCard({
   accent = "text-chart-1",
   delta,
   invertDelta = false,
+  sub,
   spark,
 }: StatCardProps) {
   const hasDelta = delta != null && Number.isFinite(delta);
@@ -33,7 +37,7 @@ export function StatCard({
 
   return (
     <Card className="overflow-hidden">
-      <CardContent className="p-5">
+      <CardContent className="flex h-full flex-col p-5">
         <div className="flex items-start justify-between">
           <p className="text-sm font-medium text-muted-foreground">{label}</p>
           {Icon && <Icon className={cn("h-4 w-4", accent)} />}
@@ -43,21 +47,23 @@ export function StatCard({
           {unit && <span className="text-sm text-muted-foreground">{unit}</span>}
         </div>
 
-        {hasDelta && (
-          <div
-            className={cn(
-              "mt-1 flex items-center gap-1 text-xs font-medium",
-              good ? "text-emerald-500" : "text-rose-500",
-            )}
-          >
-            {up ? <TrendingUp className="h-3.5 w-3.5" /> : <TrendingDown className="h-3.5 w-3.5" />}
-            {Math.abs(delta as number).toFixed(1)}%
-            <span className="font-normal text-muted-foreground">vs prev.</span>
-          </div>
-        )}
+        <div className="mt-1 flex items-center gap-2 text-xs">
+          {hasDelta && (
+            <span
+              className={cn(
+                "flex items-center gap-1 font-medium",
+                good ? "text-emerald-500" : "text-rose-500",
+              )}
+            >
+              {up ? <TrendingUp className="h-3.5 w-3.5" /> : <TrendingDown className="h-3.5 w-3.5" />}
+              {Math.abs(delta as number).toFixed(1)}%
+            </span>
+          )}
+          {sub && <span className="text-muted-foreground">{sub}</span>}
+        </div>
 
         {spark && (
-          <div className="mt-3">
+          <div className="mt-auto pt-3">
             <Sparkline data={spark.data} dataKey={spark.dataKey} color={spark.color} />
           </div>
         )}

--- a/components/dashboard/table-pagination.tsx
+++ b/components/dashboard/table-pagination.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+/** Reusable client-side pagination footer for tables. Pages are 0-indexed. */
+export function TablePagination({
+  page,
+  pageSize,
+  total,
+  onPageChange,
+  onPageSizeChange,
+  pageSizeOptions = [25, 50, 100],
+}: {
+  page: number;
+  pageSize: number;
+  total: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (size: number) => void;
+  pageSizeOptions?: number[];
+}) {
+  const pageCount = Math.max(1, Math.ceil(total / pageSize));
+  const start = total === 0 ? 0 : page * pageSize + 1;
+  const end = Math.min(total, (page + 1) * pageSize);
+
+  return (
+    <div className="flex flex-col gap-3 px-6 pt-3 sm:flex-row sm:items-center sm:justify-between">
+      <p className="text-sm text-muted-foreground tabular-nums">
+        {start.toLocaleString()}–{end.toLocaleString()} of {total.toLocaleString()}
+      </p>
+      <div className="flex items-center gap-2">
+        <Select value={String(pageSize)} onValueChange={(v) => onPageSizeChange(Number(v))}>
+          <SelectTrigger className="h-8 w-[110px]">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {pageSizeOptions.map((s) => (
+              <SelectItem key={s} value={String(s)}>
+                {s} / page
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Button
+          variant="outline"
+          size="icon-sm"
+          disabled={page <= 0}
+          onClick={() => onPageChange(page - 1)}
+          aria-label="Previous page"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+        <span className="min-w-[5rem] text-center text-sm tabular-nums">
+          {page + 1} / {pageCount}
+        </span>
+        <Button
+          variant="outline"
+          size="icon-sm"
+          disabled={page >= pageCount - 1}
+          onClick={() => onPageChange(page + 1)}
+          aria-label="Next page"
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/components/ui/popover.tsx
+++ b/components/ui/popover.tsx
@@ -1,0 +1,48 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "start",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-72 origin-(--radix-popover-content-transform-origin) rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-hidden data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverAnchor({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Anchor>) {
+  return <PopoverPrimitive.Anchor data-slot="popover-anchor" {...props} />
+}
+
+export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor }

--- a/lib/health/workout-types.ts
+++ b/lib/health/workout-types.ts
@@ -67,7 +67,7 @@ export const CATEGORY_LABELS: Record<WorkoutCategory, string> = {
 
 export const CATEGORY_ACCENT: Record<WorkoutCategory, string> = {
   cardio: "text-chart-1",
-  strength: "text-chart-3",
+  strength: "text-workout",
   sport: "text-chart-4",
   mind: "text-chart-2",
   other: "text-muted-foreground",

--- a/lib/queries/keys.ts
+++ b/lib/queries/keys.ts
@@ -8,6 +8,7 @@ export const queryKeys = {
   workouts: (filters: WorkoutFilters) => ["workouts", filters] as const,
   workout: (id: string) => ["workout", id] as const,
   workoutRoute: (workoutId: string) => ["workout-route", workoutId] as const,
+  workoutRouteIds: ["workout-route-ids"] as const,
   activitySummaries: (range: RangeKey) => ["activity-summaries", range] as const,
   sleep: (range: RangeKey) => ["sleep", range] as const,
   ecgList: ["ecg-list"] as const,

--- a/lib/queries/workouts.ts
+++ b/lib/queries/workouts.ts
@@ -10,25 +10,68 @@ export type WorkoutRoute = Tables<"workout_routes">;
 
 export interface WorkoutFilters {
   range: RangeKey;
+  /** Explicit inclusive start timestamp; overrides `range` when set. */
+  from?: string | null;
+  /** Explicit inclusive end timestamp; pairs with `from` for a custom range. */
+  until?: string | null;
   category?: WorkoutCategory | "all";
 }
+
+// Supabase caps a single response at 1000 rows, so all-time queries were
+// silently truncated. Page through with .range() until a short page is returned.
+const PAGE_SIZE = 1000;
 
 export function useWorkouts(filters: WorkoutFilters) {
   return useQuery({
     queryKey: queryKeys.workouts(filters),
     queryFn: async (): Promise<Workout[]> => {
       const supabase = createClient();
-      let query = supabase
-        .from("workouts")
-        .select("*")
-        .order("start_time", { ascending: false });
+      const since = filters.from ?? rangeStartTimestamp(filters.range);
+      const until = filters.until ?? null;
 
-      const since = rangeStartTimestamp(filters.range);
-      if (since) query = query.gte("start_time", since);
+      const all: Workout[] = [];
+      for (let offset = 0; ; offset += PAGE_SIZE) {
+        let query = supabase
+          .from("workouts")
+          .select("*")
+          .order("start_time", { ascending: false })
+          .range(offset, offset + PAGE_SIZE - 1);
+        if (since) query = query.gte("start_time", since);
+        if (until) query = query.lte("start_time", until);
 
-      const { data, error } = await query;
-      if (error) throw error;
-      return data ?? [];
+        const { data, error } = await query;
+        if (error) throw error;
+        if (!data || data.length === 0) break;
+        all.push(...data);
+        if (data.length < PAGE_SIZE) break;
+      }
+      return all;
+    },
+  });
+}
+
+/** Set of workout ids that have an associated GPS route, for map indicators. */
+export function useWorkoutRouteIds() {
+  return useQuery({
+    queryKey: queryKeys.workoutRouteIds,
+    queryFn: async (): Promise<Set<string>> => {
+      const supabase = createClient();
+      const ids = new Set<string>();
+      for (let offset = 0; ; offset += PAGE_SIZE) {
+        const res = await supabase
+          .from("workout_routes")
+          .select("workout_id")
+          .not("workout_id", "is", null)
+          .range(offset, offset + PAGE_SIZE - 1);
+        if (res.error) throw res.error;
+        // The hand-authored Database types make a single-column select resolve to
+        // `never`, so narrow the row shape explicitly.
+        const data = (res.data ?? []) as Array<{ workout_id: string | null }>;
+        if (data.length === 0) break;
+        for (const row of data) if (row.workout_id) ids.add(row.workout_id);
+        if (data.length < PAGE_SIZE) break;
+      }
+      return ids;
     },
   });
 }


### PR DESCRIPTION
Overhaul of the **Workouts tab**, addressing the full checklist.

## Changes
- **Full data fetch** — All-time queries were silently capped at Supabase's 1000-row limit. `useWorkouts` now pages through with `.range()` so every session loads.
- **Stackable filters** — Toolbar with Type (multi-select), Duration / Distance / Calories / Avg HR range popovers, and a Has-map toggle. Stack with AND logic, with a Clear control.
- **Map indicator** — New `useWorkoutRouteIds` flags rows that have a GPS route with a map-pin.
- **Pagination** — Client-side `TablePagination` with a page-size selector (25/50/100) and prev/next.
- **Apple exercise-green theme** — New `--workout` token (≈ #92E82A) applied to the nav dumbbell icon, stat-card icons, sparklines, strength icons, and the main graph.
- **Configurable chart** — Reusable `ConfigurableTrendChart` with a metric selector (Calories / Distance / Duration / Sessions / Avg HR) and a reusable `ChartTypeToggle` (bar / line / area).
- **Fuller top tiles** — Each tile now carries a sparkline, a period-trend delta, and a secondary stat (e.g. "avg/session").
- **Date range selector** — Presets plus a custom from/to picker that overrides them.

New reusable components: `Popover`, `ChartTypeToggle`, `ConfigurableTrendChart`, `TablePagination`, `NumberRangeFilter`, `DateRangeSelect`. `StatCard` gained an optional, backward-compatible `sub` slot.

## Notes
- Filters drive the whole page (tiles + chart + table), not just the table.
- `typecheck`, `lint`, and a production `build` all pass.
- Verified in-browser with temporary mock data (this worktree has no Supabase env); the mock was removed before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)