### PR TITLE
fix(workouts): give each metric a distinct colour

### DIFF
--- a/app/workouts/page.tsx
+++ b/app/workouts/page.tsx
@@ -60,7 +60,16 @@ import {
 import { WorkoutIcon } from "@/components/dashboard/workout-icon";
 import { cn } from "@/lib/utils";
 
-const WORKOUT_GREEN = "var(--workout)";
+// Each metric gets its own colour so the tiles and chart aren't a wall of green.
+// `accent` is the tailwind text token for stat-card icons; `color` is the CSS
+// value for sparklines and chart series.
+const METRIC_COLORS = {
+  sessions: { accent: "text-workout", color: "var(--workout)" },
+  calories: { accent: "text-chart-3", color: "var(--chart-3)" },
+  distance: { accent: "text-chart-2", color: "var(--chart-2)" },
+  duration: { accent: "text-chart-5", color: "var(--chart-5)" },
+  avgHr: { accent: "text-chart-4", color: "var(--chart-4)" },
+} as const;
 
 /** Trend over the range: last half vs first half of the daily series. */
 function trendDelta(values: Array<number | null>): number | null {
@@ -183,7 +192,7 @@ export default function WorkoutsPage() {
         label: "Calories",
         icon: Flame,
         unit: "kcal",
-        color: WORKOUT_GREEN,
+        color: METRIC_COLORS.calories.color,
         data: daily.map((d) => ({ date: d.date, value: d.calories })),
         valueFormatter: (v) => fmt.compactNumber(v),
       },
@@ -192,7 +201,7 @@ export default function WorkoutsPage() {
         label: "Distance",
         icon: Route,
         unit: "km",
-        color: WORKOUT_GREEN,
+        color: METRIC_COLORS.distance.color,
         data: daily.map((d) => ({ date: d.date, value: d.distance })),
         valueFormatter: (v) => fmt.number(v, v >= 100 ? 0 : 1),
       },
@@ -201,7 +210,7 @@ export default function WorkoutsPage() {
         label: "Duration",
         icon: Timer,
         unit: "min",
-        color: WORKOUT_GREEN,
+        color: METRIC_COLORS.duration.color,
         data: daily.map((d) => ({ date: d.date, value: d.duration })),
         valueFormatter: (v) => fmt.number(v, 0),
       },
@@ -209,7 +218,7 @@ export default function WorkoutsPage() {
         key: "sessions",
         label: "Sessions",
         icon: Dumbbell,
-        color: WORKOUT_GREEN,
+        color: METRIC_COLORS.sessions.color,
         data: daily.map((d) => ({ date: d.date, value: d.sessions })),
         valueFormatter: (v) => fmt.number(v, 0),
       },
@@ -218,7 +227,7 @@ export default function WorkoutsPage() {
         label: "Avg heart rate",
         icon: HeartPulse,
         unit: "bpm",
-        color: "var(--chart-4)",
+        color: METRIC_COLORS.avgHr.color,
         data: daily.map((d) => ({ date: d.date, value: d.avgHr })),
         valueFormatter: (v) => fmt.number(v, 0),
       },
@@ -262,43 +271,43 @@ export default function WorkoutsPage() {
                 label="Sessions"
                 value={fmt.number(sessions)}
                 icon={Dumbbell}
-                accent="text-workout"
+                accent={METRIC_COLORS.sessions.accent}
                 delta={trendDelta(daily.map((d) => d.sessions))}
                 sub={`${fmt.number(daily.length)} active ${daily.length === 1 ? "day" : "days"}`}
-                spark={{ data: daily, dataKey: "sessions", color: WORKOUT_GREEN }}
+                spark={{ data: daily, dataKey: "sessions", color: METRIC_COLORS.sessions.color }}
               />
               <StatCard
                 label="Calories burned"
                 value={fmt.number(totalKcal)}
                 unit="kcal"
                 icon={Flame}
-                accent="text-workout"
+                accent={METRIC_COLORS.calories.accent}
                 delta={trendDelta(daily.map((d) => d.calories))}
                 sub={sessions ? `${fmt.number(totalKcal / sessions)} avg/session` : undefined}
-                spark={{ data: daily, dataKey: "calories", color: WORKOUT_GREEN }}
+                spark={{ data: daily, dataKey: "calories", color: METRIC_COLORS.calories.color }}
               />
               <StatCard
                 label="Total distance"
                 value={fmt.number(totalKm)}
                 unit="km"
                 icon={Route}
-                accent="text-workout"
+                accent={METRIC_COLORS.distance.accent}
                 delta={trendDelta(daily.map((d) => d.distance))}
                 sub={
                   distanceSessions
                     ? `${fmt.distanceKm(totalKm / distanceSessions)} avg`
                     : "no distance logged"
                 }
-                spark={{ data: daily, dataKey: "distance", color: WORKOUT_GREEN }}
+                spark={{ data: daily, dataKey: "distance", color: METRIC_COLORS.distance.color }}
               />
               <StatCard
                 label="Time"
                 value={fmt.duration(totalMin)}
                 icon={Timer}
-                accent="text-workout"
+                accent={METRIC_COLORS.duration.accent}
                 delta={trendDelta(daily.map((d) => d.duration))}
                 sub={sessions ? `${fmt.duration(totalMin / sessions)} avg/session` : undefined}
-                spark={{ data: daily, dataKey: "duration", color: WORKOUT_GREEN }}
+                spark={{ data: daily, dataKey: "duration", color: METRIC_COLORS.duration.color }}
               />
             </div>
 

--- a/lib/health/workout-types.ts
+++ b/lib/health/workout-types.ts
@@ -67,7 +67,7 @@ export const CATEGORY_LABELS: Record<WorkoutCategory, string> = {
 
 export const CATEGORY_ACCENT: Record<WorkoutCategory, string> = {
   cardio: "text-chart-1",
-  strength: "text-workout",
+  strength: "text-chart-3",
   sport: "text-chart-4",
   mind: "text-chart-2",
   other: "text-muted-foreground",


### PR DESCRIPTION
Follow-up to #9. The Workouts tiles and chart all used the Apple-green domain accent, which read as a wall of green. Each metric now has its own colour.

| Metric | Colour |
|---|---|
| Sessions | green (`--workout`) |
| Calories | orange (`--chart-3`) |
| Distance | teal (`--chart-2`) |
| Duration / Time | violet (`--chart-5`) |
| Avg heart rate | red (`--chart-4`) |

The stat-card icon, sparkline, and chart series share the metric's colour, and the chart recolours as you switch metrics. The **nav/dumbbell stays green** as the Workouts domain identity, and the table's strength icon reverts to orange so it isn't a second green next to cardio.

Verified in-browser (tile icon colours confirmed distinct via computed styles); `typecheck` and `lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)