### PR TITLE
Richer sleep dashboard + chart info tooltips across all pages

### DIFF
--- a/app/activity/page.tsx
+++ b/app/activity/page.tsx
@@ -8,7 +8,8 @@ import { RangeSelect } from "@/components/dashboard/range-select";
 import { StatCard } from "@/components/dashboard/stat-card";
 import { TrendChart } from "@/components/charts/trend-chart";
 import { CardGridSkeleton, ChartSkeleton, QueryView } from "@/components/dashboard/states";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ChartHeader } from "@/components/dashboard/chart-header";
+import { Card, CardContent } from "@/components/ui/card";
 import type { RangeKey } from "@/lib/queries/ranges";
 import * as fmt from "@/lib/format";
 import { mean, sum, deltaPct } from "@/lib/stats";
@@ -45,9 +46,10 @@ export default function ActivityPage() {
             </div>
 
             <Card>
-              <CardHeader>
-                <CardTitle className="text-base">Daily steps</CardTitle>
-              </CardHeader>
+              <ChartHeader
+                title="Daily steps"
+                info="Total steps counted each day by your iPhone and Apple Watch. Bar height is that day's step count over the selected range."
+              />
               <CardContent>
                 <TrendChart data={m} series={[{ key: "steps", label: "Steps", type: "bar", color: "var(--chart-1)" }]} />
               </CardContent>
@@ -55,17 +57,19 @@ export default function ActivityPage() {
 
             <div className="grid gap-6 lg:grid-cols-2">
               <Card>
-                <CardHeader>
-                  <CardTitle className="text-base">Active energy</CardTitle>
-                </CardHeader>
+                <ChartHeader
+                  title="Active energy"
+                  info="Active calories burned per day — energy spent on movement above your resting metabolism, the figure behind the red Move ring."
+                />
                 <CardContent>
                   <TrendChart data={m} height={260} series={[{ key: "active_energy", label: "Active energy", color: "var(--chart-3)", unit: "kcal" }]} />
                 </CardContent>
               </Card>
               <Card>
-                <CardHeader>
-                  <CardTitle className="text-base">Distance</CardTitle>
-                </CardHeader>
+                <ChartHeader
+                  title="Distance"
+                  info="Distance travelled on foot each day (walking and running), in kilometres, as tracked by your devices."
+                />
                 <CardContent>
                   <TrendChart data={m} height={260} series={[{ key: "distance_km", label: "Distance", color: "var(--chart-2)", unit: "km" }]} />
                 </CardContent>

--- a/app/body/page.tsx
+++ b/app/body/page.tsx
@@ -8,7 +8,8 @@ import { RangeSelect } from "@/components/dashboard/range-select";
 import { StatCard } from "@/components/dashboard/stat-card";
 import { TrendChart } from "@/components/charts/trend-chart";
 import { CardGridSkeleton, ChartSkeleton, QueryView } from "@/components/dashboard/states";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ChartHeader } from "@/components/dashboard/chart-header";
+import { Card, CardContent } from "@/components/ui/card";
 import type { RangeKey } from "@/lib/queries/ranges";
 import * as fmt from "@/lib/format";
 import { latest, deltaPct } from "@/lib/stats";
@@ -60,9 +61,10 @@ export default function BodyPage() {
             </div>
 
             <Card>
-              <CardHeader>
-                <CardTitle className="text-base">Weight</CardTitle>
-              </CardHeader>
+              <ChartHeader
+                title="Weight"
+                info="Body weight over time, in kilograms, from each logged measurement. The range defaults to a year so the trend is easy to see."
+              />
               <CardContent>
                 <TrendChart data={m} series={[{ key: "weight_kg", label: "Weight", color: "var(--chart-5)", unit: "kg" }]} valueFormatter={(v) => v.toFixed(0)} />
               </CardContent>
@@ -70,9 +72,10 @@ export default function BodyPage() {
 
             <div className="grid gap-6 lg:grid-cols-2">
               <Card>
-                <CardHeader>
-                  <CardTitle className="text-base">BMI</CardTitle>
-                </CardHeader>
+                <ChartHeader
+                  title="BMI"
+                  info="Body Mass Index — weight relative to height. Apple records it directly when available; otherwise it's derived from your weight and height."
+                />
                 <CardContent>
                   {hasBmi ? (
                     <TrendChart data={m} height={240} series={[{ key: "bmi", label: "BMI", type: "line", color: "var(--chart-3)" }]} valueFormatter={(v) => v.toFixed(0)} />
@@ -82,9 +85,10 @@ export default function BodyPage() {
                 </CardContent>
               </Card>
               <Card>
-                <CardHeader>
-                  <CardTitle className="text-base">Body fat</CardTitle>
-                </CardHeader>
+                <ChartHeader
+                  title="Body fat"
+                  info="Body fat percentage over time. These readings come from a smart scale or manual entry — Apple Watch doesn't measure body composition."
+                />
                 <CardContent>
                   {hasBodyFat ? (
                     <TrendChart data={m} height={240} series={[{ key: "body_fat_pct", label: "Body fat", type: "line", color: "var(--chart-4)", unit: "%" }]} valueFormatter={(v) => `${v.toFixed(0)}%`} />

--- a/app/ecg/[id]/page.tsx
+++ b/app/ecg/[id]/page.tsx
@@ -6,8 +6,9 @@ import { ArrowLeft, HeartPulse } from "lucide-react";
 import { useEcg } from "@/lib/queries/ecg";
 import { PageHeader } from "@/components/dashboard/page-header";
 import { EcgWaveform } from "@/components/charts/ecg-waveform";
+import { ChartHeader } from "@/components/dashboard/chart-header";
 import { ChartSkeleton, ErrorState } from "@/components/dashboard/states";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import * as fmt from "@/lib/format";
@@ -45,11 +46,12 @@ export default function EcgDetailPage() {
           />
 
           <Card className="mb-6">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2 text-base">
-                <HeartPulse className="h-4 w-4 text-chart-4" /> Lead I
-              </CardTitle>
-            </CardHeader>
+            <ChartHeader
+              icon={HeartPulse}
+              iconClass="text-chart-4"
+              title="Lead I"
+              info="The single-lead electrocardiogram trace recorded by Apple Watch — voltage over time across one heartbeat sequence. Apple's on-device algorithm classifies the rhythm (e.g. sinus rhythm or atrial fibrillation)."
+            />
             <CardContent>
               <EcgWaveform samples={samples} />
               <div className="mt-3 grid grid-cols-2 gap-3 text-sm sm:grid-cols-4">

--- a/app/hearing/page.tsx
+++ b/app/hearing/page.tsx
@@ -8,7 +8,8 @@ import { RangeSelect } from "@/components/dashboard/range-select";
 import { StatCard } from "@/components/dashboard/stat-card";
 import { TrendChart } from "@/components/charts/trend-chart";
 import { CardGridSkeleton, ChartSkeleton, QueryView } from "@/components/dashboard/states";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ChartHeader } from "@/components/dashboard/chart-header";
+import { Card, CardContent } from "@/components/ui/card";
 import type { RangeKey } from "@/lib/queries/ranges";
 import * as fmt from "@/lib/format";
 import { mean } from "@/lib/stats";
@@ -43,11 +44,12 @@ export default function HearingPage() {
             </div>
 
             <Card>
-              <CardHeader>
-                <CardTitle className="flex items-center gap-2 text-base">
-                  <Ear className="h-4 w-4 text-chart-2" /> Audio exposure
-                </CardTitle>
-              </CardHeader>
+              <ChartHeader
+                icon={Ear}
+                iconClass="text-chart-2"
+                title="Audio exposure"
+                info="Average daily sound levels in decibels — environmental noise around you and audio played through headphones. Sustained high levels raise the risk of long-term hearing loss."
+              />
               <CardContent>
                 <TrendChart
                   data={m}

--- a/app/heart/page.tsx
+++ b/app/heart/page.tsx
@@ -12,6 +12,7 @@ import { ReadinessCard } from "@/components/dashboard/readiness-card";
 import { computeReadiness } from "@/lib/health/readiness";
 import { TrendChart } from "@/components/charts/trend-chart";
 import { CardGridSkeleton, ChartSkeleton, QueryView } from "@/components/dashboard/states";
+import { ChartHeader } from "@/components/dashboard/chart-header";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -54,19 +55,21 @@ export default function HeartPage() {
 
             <div className="grid gap-6 lg:grid-cols-3">
               <Card>
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2 text-base">
-                    <Gauge className="h-4 w-4 text-chart-1" /> Readiness
-                  </CardTitle>
-                </CardHeader>
+                <ChartHeader
+                  icon={Gauge}
+                  iconClass="text-chart-1"
+                  title="Readiness"
+                  info="A 0–100 daily score blending HRV, resting heart rate, sleep and the previous day's exercise load against your own recent baseline. Higher means better recovered and readier to train."
+                />
                 <CardContent>
                   <ReadinessCard days={readiness} />
                 </CardContent>
               </Card>
               <Card className="lg:col-span-2">
-                <CardHeader>
-                  <CardTitle className="text-base">Resting heart rate & HRV</CardTitle>
-                </CardHeader>
+                <ChartHeader
+                  title="Resting heart rate & HRV"
+                  info="Resting heart rate (beats per minute, lower is generally fitter) and heart rate variability (SDNN in milliseconds, higher generally signals better recovery), tracked together over time."
+                />
                 <CardContent>
                   <TrendChart
                     data={m}
@@ -81,19 +84,21 @@ export default function HeartPage() {
 
             <div className="grid gap-6 lg:grid-cols-2">
               <Card>
-                <CardHeader>
-                  <CardTitle className="text-base">VO₂ Max</CardTitle>
-                </CardHeader>
+                <ChartHeader
+                  title="VO₂ Max"
+                  info="Estimated maximum oxygen uptake (ml/kg/min) — Apple's measure of cardio fitness. It moves slowly; a rising trend means your aerobic fitness is improving."
+                />
                 <CardContent>
                   <TrendChart data={m} height={260} series={[{ key: "vo2max", label: "VO₂ Max", color: "var(--chart-3)" }]} valueFormatter={(v) => v.toFixed(0)} />
                 </CardContent>
               </Card>
               <Card>
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2 text-base">
-                    <Wind className="h-4 w-4 text-chart-2" /> Respiratory rate
-                  </CardTitle>
-                </CardHeader>
+                <ChartHeader
+                  icon={Wind}
+                  iconClass="text-chart-2"
+                  title="Respiratory rate"
+                  info="Breaths per minute, mostly measured during sleep. A stable resting rate is normal; a sustained jump can accompany illness, stress or poor recovery."
+                />
                 <CardContent>
                   <TrendChart data={m} height={260} series={[{ key: "respiratory_rate", label: "Respiratory rate", type: "line", color: "var(--chart-2)", unit: "br/min" }]} valueFormatter={(v) => v.toFixed(0)} />
                 </CardContent>

--- a/app/map/page.tsx
+++ b/app/map/page.tsx
@@ -6,6 +6,7 @@ import { Route as RouteIcon, Flame, Palette, Sparkles, Trophy } from "lucide-rea
 import { useAllRoutes } from "@/lib/queries/all-routes";
 import { workoutMeta } from "@/lib/health/workout-types";
 import { PageHeader } from "@/components/dashboard/page-header";
+import { InfoHint } from "@/components/dashboard/info-hint";
 import { QueryView } from "@/components/dashboard/states";
 import { useActiveAreas, haversineKm, type ActiveArea } from "@/lib/map/areas";
 import type { MapFocus, MapRoute, RouteColorMode } from "@/components/dashboard/all-routes-map";
@@ -180,6 +181,7 @@ export default function MapPage() {
                     ))}
                   </SelectContent>
                 </Select>
+                <InfoHint text="Every outdoor workout with GPS, overlaid on one map. In heat mode brighter areas are where your routes overlap most; in by-sport mode each activity gets its own colour. Filter by sport and year, and use the on-map buttons to jump to new areas or your longest route." />
               </div>
             </div>
 

--- a/app/mobility/page.tsx
+++ b/app/mobility/page.tsx
@@ -8,7 +8,8 @@ import { RangeSelect } from "@/components/dashboard/range-select";
 import { StatCard } from "@/components/dashboard/stat-card";
 import { TrendChart } from "@/components/charts/trend-chart";
 import { CardGridSkeleton, ChartSkeleton, QueryView } from "@/components/dashboard/states";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ChartHeader } from "@/components/dashboard/chart-header";
+import { Card, CardContent } from "@/components/ui/card";
 import type { RangeKey } from "@/lib/queries/ranges";
 import * as fmt from "@/lib/format";
 import { mean, latest } from "@/lib/stats";
@@ -47,9 +48,10 @@ export default function MobilityPage() {
             </div>
 
             <Card>
-              <CardHeader>
-                <CardTitle className="text-base">Walking speed & step length</CardTitle>
-              </CardHeader>
+              <ChartHeader
+                title="Walking speed & step length"
+                info="Your average walking pace (km/h) and how far you travel per step (cm). Both are gauges of gait health — they tend to dip when you're tired, injured or unwell."
+              />
               <CardContent>
                 <TrendChart
                   data={m}
@@ -64,11 +66,12 @@ export default function MobilityPage() {
 
             <div className="grid gap-6 lg:grid-cols-2">
               <Card>
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2 text-base">
-                    <Activity className="h-4 w-4 text-chart-4" /> Gait symmetry
-                  </CardTitle>
-                </CardHeader>
+                <ChartHeader
+                  icon={Activity}
+                  iconClass="text-chart-4"
+                  title="Gait symmetry"
+                  info="Walking asymmetry is the percentage of time your steps are uneven between legs; double support is the share of each stride with both feet on the ground. Lower is steadier — both rise with fatigue or injury."
+                />
                 <CardContent>
                   <TrendChart
                     data={m}
@@ -82,9 +85,10 @@ export default function MobilityPage() {
                 </CardContent>
               </Card>
               <Card>
-                <CardHeader>
-                  <CardTitle className="text-base">Stair speed</CardTitle>
-                </CardHeader>
+                <ChartHeader
+                  title="Stair speed"
+                  info="How quickly you climb and descend stairs (metres per second), measured by Apple Watch. Higher speeds reflect better lower-body strength and balance."
+                />
                 <CardContent>
                   <TrendChart
                     data={m}

--- a/app/nutrition/page.tsx
+++ b/app/nutrition/page.tsx
@@ -8,7 +8,8 @@ import { RangeSelect } from "@/components/dashboard/range-select";
 import { StatCard } from "@/components/dashboard/stat-card";
 import { TrendChart } from "@/components/charts/trend-chart";
 import { CardGridSkeleton, ChartSkeleton, QueryView } from "@/components/dashboard/states";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { ChartHeader } from "@/components/dashboard/chart-header";
+import { Card, CardContent } from "@/components/ui/card";
 import type { RangeKey } from "@/lib/queries/ranges";
 import * as fmt from "@/lib/format";
 import { mean } from "@/lib/stats";
@@ -45,9 +46,10 @@ export default function NutritionPage() {
             </div>
 
             <Card>
-              <CardHeader>
-                <CardTitle className="text-base">Energy intake</CardTitle>
-              </CardHeader>
+              <ChartHeader
+                title="Energy intake"
+                info="Total calories you logged eating each day. Only as complete as what's recorded in Apple Health via a food-tracking app."
+              />
               <CardContent>
                 <TrendChart data={m} series={[{ key: "diet_energy_kcal", label: "Calories", type: "bar", color: "var(--chart-3)" }]} />
               </CardContent>
@@ -55,11 +57,12 @@ export default function NutritionPage() {
 
             <div className="grid gap-6 lg:grid-cols-2">
               <Card>
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2 text-base">
-                    <Wheat className="h-4 w-4 text-chart-1" /> Macronutrients
-                  </CardTitle>
-                </CardHeader>
+                <ChartHeader
+                  icon={Wheat}
+                  iconClass="text-chart-1"
+                  title="Macronutrients"
+                  info="Grams of carbohydrate, protein and fat logged per day, stacked so the full bar is your total macros for that day."
+                />
                 <CardContent>
                   <TrendChart
                     data={m}
@@ -74,11 +77,12 @@ export default function NutritionPage() {
                 </CardContent>
               </Card>
               <Card>
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2 text-base">
-                    <Croissant className="h-4 w-4 text-chart-5" /> Sugar &amp; fibre
-                  </CardTitle>
-                </CardHeader>
+                <ChartHeader
+                  icon={Croissant}
+                  iconClass="text-chart-5"
+                  title="Sugar & fibre"
+                  info="Grams of sugar and dietary fibre logged each day. Watching sugar down and fibre up is a simple marker of diet quality."
+                />
                 <CardContent>
                   <TrendChart
                     data={m}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -25,6 +25,7 @@ import { deriveInsights } from "@/lib/insights/engine";
 import { computeReadiness } from "@/lib/health/readiness";
 import { InsightList } from "@/components/dashboard/insight-list";
 import { ReadinessCard } from "@/components/dashboard/readiness-card";
+import { InfoHint } from "@/components/dashboard/info-hint";
 import { PageHeader } from "@/components/dashboard/page-header";
 import { StatCard } from "@/components/dashboard/stat-card";
 import { ActivityRings } from "@/components/dashboard/activity-rings";
@@ -103,7 +104,10 @@ export default function OverviewPage() {
           return (
             <div className="space-y-6">
               {/* Hero */}
-              <Card className="overflow-hidden">
+              <Card className="relative overflow-hidden">
+                <div className="absolute right-3 top-3 z-10">
+                  <InfoHint text="Your most recent Apple Watch activity rings — Move (active calories), Exercise (brisk-activity minutes) and Stand (hours with at least a minute standing) — alongside today's headline vitals." />
+                </div>
                 <CardContent className="grid gap-6 p-6 lg:grid-cols-[auto_1fr] lg:items-center lg:gap-10">
                   <div className="flex items-center justify-center gap-5 sm:justify-start">
                     <ActivityRings
@@ -241,7 +245,10 @@ export default function OverviewPage() {
                       <Gauge className="h-4 w-4 text-chart-1" />
                       Readiness
                     </CardTitle>
-                    <span className="text-xs text-muted-foreground">Today</span>
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs text-muted-foreground">Today</span>
+                      <InfoHint text="A 0–100 daily recovery score blending HRV, resting heart rate, sleep and the previous day's exercise load against your own recent baseline. Higher means better recovered." />
+                    </div>
                   </CardHeader>
                   <CardContent>
                     <ReadinessCard days={readiness} />
@@ -254,7 +261,10 @@ export default function OverviewPage() {
                 <Card className="lg:col-span-2">
                   <CardHeader className="flex-row items-center justify-between">
                     <CardTitle className="text-base">Activity streak</CardTitle>
-                    <span className="text-xs text-muted-foreground">Past year</span>
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs text-muted-foreground">Past year</span>
+                      <InfoHint text="Each square is a day in the past year; brighter means more exercise minutes. A day counts toward your streak when the Apple exercise ring is closed (≥30 min)." />
+                    </div>
                   </CardHeader>
                   <CardContent className="space-y-5">
                     <div className="grid grid-cols-3 gap-3">
@@ -324,7 +334,11 @@ export default function OverviewPage() {
 
               {/* Trends */}
               <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-                <TrendCard title="Heart health" subtitle="Last 90 days">
+                <TrendCard
+                  title="Heart health"
+                  subtitle="Last 90 days"
+                  info="Resting heart rate (bpm) and heart rate variability (ms) over the last 90 days — two of the clearest day-to-day signals of cardiovascular health and recovery."
+                >
                   <TrendChart
                     height={220}
                     data={m}
@@ -335,7 +349,11 @@ export default function OverviewPage() {
                   />
                 </TrendCard>
 
-                <TrendCard title="Sleep duration" subtitle="Last 30 days">
+                <TrendCard
+                  title="Sleep duration"
+                  subtitle="Last 30 days"
+                  info="Hours asleep each night over the last 30 days. See the Sleep tab for the full stage, schedule and quality breakdown."
+                >
                   <TrendChart
                     height={220}
                     data={m30}
@@ -345,7 +363,11 @@ export default function OverviewPage() {
                 </TrendCard>
 
                 {hasVo2 && (
-                  <TrendCard title="Cardio fitness" subtitle="VO₂ Max · past year">
+                  <TrendCard
+                    title="Cardio fitness"
+                    subtitle="VO₂ Max · past year"
+                    info="Estimated VO₂ Max (ml/kg/min) over the past year — Apple's headline measure of aerobic fitness. It changes slowly, so the trend matters more than any single point."
+                  >
                     <TrendChart
                       height={220}
                       data={vo2Series}
@@ -355,7 +377,11 @@ export default function OverviewPage() {
                 )}
 
                 {hasWeight && (
-                  <TrendCard title="Body weight" subtitle="Past year">
+                  <TrendCard
+                    title="Body weight"
+                    subtitle="Past year"
+                    info="Body weight (kg) over the past year from each logged measurement. See the Body tab for BMI and body composition."
+                  >
                     <TrendChart
                       height={220}
                       data={weightSeries}
@@ -470,17 +496,22 @@ function MiniStat({
 function TrendCard({
   title,
   subtitle,
+  info,
   children,
 }: {
   title: string;
   subtitle?: string;
+  info: string;
   children: ReactNode;
 }) {
   return (
     <Card>
       <CardHeader className="flex-row items-center justify-between">
         <CardTitle className="text-base">{title}</CardTitle>
-        {subtitle && <span className="text-xs text-muted-foreground">{subtitle}</span>}
+        <div className="flex items-center gap-2">
+          {subtitle && <span className="text-xs text-muted-foreground">{subtitle}</span>}
+          <InfoHint text={info} />
+        </div>
       </CardHeader>
       <CardContent>{children}</CardContent>
     </Card>

--- a/app/sleep/page.tsx
+++ b/app/sleep/page.tsx
@@ -1,27 +1,57 @@
 "use client";
 
-import { useState } from "react";
-import { Moon, Gauge, Sparkles, BedDouble } from "lucide-react";
-import { useSleepSessions } from "@/lib/queries/sleep";
+import { useMemo, useState } from "react";
+import {
+  Moon,
+  Gauge,
+  BedDouble,
+  Sunrise,
+  CalendarDays,
+  Clock,
+  Thermometer,
+  Wind,
+  Droplets,
+  HeartPulse,
+  Activity,
+  Hourglass,
+} from "lucide-react";
+import { useSleepSessions, type SleepSession } from "@/lib/queries/sleep";
+import { useDailyMetrics, type DailyMetric } from "@/lib/queries/metrics";
 import { PageHeader } from "@/components/dashboard/page-header";
 import { RangeSelect } from "@/components/dashboard/range-select";
 import { StatCard } from "@/components/dashboard/stat-card";
 import { TrendChart } from "@/components/charts/trend-chart";
+import { ConfigurableTrendChart, type ChartMetric } from "@/components/charts/configurable-trend-chart";
+import { ChartTypeToggle, type ChartType } from "@/components/charts/chart-type-toggle";
+import { TablePagination } from "@/components/dashboard/table-pagination";
+import { ChartHeader } from "@/components/dashboard/chart-header";
 import { CardGridSkeleton, ChartSkeleton, QueryView } from "@/components/dashboard/states";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import type { RangeKey } from "@/lib/queries/ranges";
 import * as fmt from "@/lib/format";
-import { mean } from "@/lib/stats";
+import { mean, deltaPct } from "@/lib/stats";
+import {
+  circularTimeStats,
+  clockFromNoonHours,
+  clockLabel,
+  efficiencyPct,
+  hoursSinceAnchorNoon,
+  minutesIntoDay,
+  stageBreakdown,
+  weekdayAverages,
+  type StageStat,
+} from "@/lib/sleep";
 
 export default function SleepPage() {
   const [range, setRange] = useState<RangeKey>("90d");
   const query = useSleepSessions(range);
+  const dailyQuery = useDailyMetrics(range);
 
   return (
     <>
       <PageHeader
         title="Sleep"
-        description="Sleep stages, quality and duration across your nights."
+        description="Sleep stages, quality, schedule and how your nights track your recovery."
         actions={<RangeSelect value={range} onChange={setRange} />}
       />
 
@@ -35,61 +65,417 @@ export default function SleepPage() {
         }
         isEmpty={(d) => d.length === 0}
       >
-        {(sessions) => {
-          const data = sessions.map((s) => ({
-            date: s.start_time.slice(0, 10),
-            deep: s.deep_min ?? 0,
-            rem: s.rem_min ?? 0,
-            light: s.light_min ?? 0,
-            awake: s.awake_min ?? 0,
-            quality: s.quality_pct ?? null,
-            hours: s.duration_min != null ? s.duration_min / 60 : null,
-          }));
-
-          return (
-            <div className="space-y-6">
-              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-                <StatCard label="Avg time asleep" value={fmt.duration(mean(sessions.map((s) => s.duration_min)))} icon={BedDouble} accent="text-chart-2" />
-                <StatCard label="Avg quality" value={fmt.number(mean(sessions.map((s) => s.quality_pct)))} unit="%" icon={Gauge} accent="text-chart-1" />
-                <StatCard label="Avg deep sleep" value={fmt.duration(mean(sessions.map((s) => s.deep_min)))} icon={Moon} accent="text-chart-5" />
-                <StatCard label="Avg REM" value={fmt.duration(mean(sessions.map((s) => s.rem_min)))} icon={Sparkles} accent="text-chart-3" />
-              </div>
-
-              <Card>
-                <CardHeader>
-                  <CardTitle className="text-base">Sleep stages</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <TrendChart
-                    data={data}
-                    valueFormatter={(v) => `${Math.round(v / 60)}h`}
-                    series={[
-                      { key: "deep", label: "Deep", color: "var(--chart-5)", stackId: "s" },
-                      { key: "rem", label: "REM", color: "var(--chart-3)", stackId: "s" },
-                      { key: "light", label: "Light", color: "var(--chart-2)", stackId: "s" },
-                      { key: "awake", label: "Awake", color: "var(--chart-4)", stackId: "s" },
-                    ]}
-                  />
-                </CardContent>
-              </Card>
-
-              <Card>
-                <CardHeader>
-                  <CardTitle className="text-base">Sleep quality</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <TrendChart
-                    data={data}
-                    height={240}
-                    series={[{ key: "quality", label: "Quality", type: "line", color: "var(--chart-1)", unit: "%" }]}
-                    valueFormatter={(v) => `${v.toFixed(0)}%`}
-                  />
-                </CardContent>
-              </Card>
-            </div>
-          );
-        }}
+        {(sessions) => (
+          <SleepDashboard sessions={sessions} daily={dailyQuery.data ?? []} />
+        )}
       </QueryView>
     </>
+  );
+}
+
+function SleepDashboard({
+  sessions,
+  daily: dailyMetrics,
+}: {
+  sessions: SleepSession[];
+  daily: DailyMetric[];
+}) {
+  // Per-night series for charts and sparklines.
+  const data = useMemo(
+    () =>
+      sessions.map((s) => ({
+        date: s.start_time.slice(0, 10),
+        deep: s.deep_min ?? 0,
+        rem: s.rem_min ?? 0,
+        light: s.light_min ?? 0,
+        awake: s.awake_min ?? 0,
+        duration_min: s.duration_min ?? null,
+        quality_pct: s.quality_pct ?? null,
+      })),
+    [sessions],
+  );
+
+  const bedtimes = circularTimeStats(sessions.map((s) => minutesIntoDay(s.start_time)));
+  const waketimes = circularTimeStats(
+    sessions.map((s) => (s.end_time ? minutesIntoDay(s.end_time) : null)),
+  );
+  const { stages, totalMin } = stageBreakdown(sessions);
+  const weekday = weekdayAverages(sessions);
+
+  // Bedtime / wake-up laid onto one continuous evening→morning axis.
+  const schedule = useMemo(
+    () =>
+      sessions
+        .filter((s) => s.end_time)
+        .map((s) => ({
+          date: s.start_time.slice(0, 10),
+          bedtime: hoursSinceAnchorNoon(s.start_time, s.start_time),
+          wake: hoursSinceAnchorNoon(s.end_time as string, s.start_time),
+        })),
+    [sessions],
+  );
+
+  // Sleep & recovery vitals — per-night quality/duration alongside the
+  // overnight physiology rolled up into daily_metrics.
+  const vitals: ChartMetric[] = useMemo(() => {
+    const fromDaily = (key: keyof DailyMetric): Array<{ date: string; value: number | null }> =>
+      dailyMetrics.map((d) => ({ date: String(d.date), value: (d[key] as number | null) ?? null }));
+    const hasDaily = (key: keyof DailyMetric) => dailyMetrics.some((d) => d[key] != null);
+
+    const list: ChartMetric[] = [
+      {
+        key: "efficiency",
+        label: "Sleep efficiency",
+        unit: "%",
+        color: "var(--chart-1)",
+        icon: Gauge,
+        data: sessions.map((s) => ({ date: s.start_time.slice(0, 10), value: efficiencyPct(s) })),
+        valueFormatter: (v) => v.toFixed(0),
+      },
+      {
+        key: "asleep",
+        label: "Time asleep",
+        unit: "h",
+        color: "var(--chart-2)",
+        icon: Hourglass,
+        data: sessions.map((s) => ({
+          date: s.start_time.slice(0, 10),
+          value: s.duration_min != null ? s.duration_min / 60 : null,
+        })),
+        valueFormatter: (v) => v.toFixed(1),
+      },
+    ];
+    if (hasDaily("sleeping_wrist_temp_c"))
+      list.push({ key: "wrist_temp", label: "Wrist temperature", unit: "°C", color: "var(--chart-4)", icon: Thermometer, data: fromDaily("sleeping_wrist_temp_c"), valueFormatter: (v) => v.toFixed(1) });
+    if (hasDaily("respiratory_rate"))
+      list.push({ key: "resp", label: "Respiratory rate", unit: "br/min", color: "var(--chart-2)", icon: Wind, data: fromDaily("respiratory_rate"), valueFormatter: (v) => v.toFixed(1) });
+    if (hasDaily("blood_oxygen"))
+      list.push({ key: "spo2", label: "Blood oxygen", unit: "%", color: "var(--chart-3)", icon: Droplets, data: fromDaily("blood_oxygen"), valueFormatter: (v) => v.toFixed(1) });
+    if (hasDaily("resting_hr"))
+      list.push({ key: "resting_hr", label: "Resting HR", unit: "bpm", color: "var(--chart-4)", icon: HeartPulse, data: fromDaily("resting_hr"), valueFormatter: (v) => v.toFixed(0) });
+    if (hasDaily("hrv_ms"))
+      list.push({ key: "hrv", label: "HRV", unit: "ms", color: "var(--chart-1)", icon: Activity, data: fromDaily("hrv_ms"), valueFormatter: (v) => v.toFixed(0) });
+    return list;
+  }, [sessions, dailyMetrics]);
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          label="Avg time asleep"
+          value={fmt.duration(mean(sessions.map((s) => s.duration_min)))}
+          icon={BedDouble}
+          accent="text-chart-2"
+          delta={deltaPct(data.map((d) => d.duration_min), 7)}
+          spark={{ data, dataKey: "duration_min", color: "var(--chart-2)" }}
+          sub={`${sessions.length} nights`}
+        />
+        <StatCard
+          label="Avg efficiency"
+          value={fmt.number(mean(sessions.map((s) => efficiencyPct(s))))}
+          unit="%"
+          icon={Gauge}
+          accent="text-chart-1"
+          delta={deltaPct(data.map((d) => d.quality_pct), 7)}
+          spark={{ data, dataKey: "quality_pct", color: "var(--chart-1)" }}
+        />
+        <StatCard
+          label="Avg bedtime"
+          value={clockLabel(bedtimes.mean)}
+          icon={Moon}
+          accent="text-chart-5"
+          sub={bedtimes.stdev != null ? `±${Math.round(bedtimes.stdev)}m consistency` : undefined}
+        />
+        <StatCard
+          label="Avg wake-up"
+          value={clockLabel(waketimes.mean)}
+          icon={Sunrise}
+          accent="text-chart-3"
+          sub={waketimes.stdev != null ? `±${Math.round(waketimes.stdev)}m consistency` : undefined}
+        />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <Card>
+          <ChartHeader
+            title="Stage composition"
+            description={`Average night · ${fmt.duration(totalMin)} in bed`}
+            info="How an average night breaks down across the four sleep stages — deep, REM, light and time awake — shown as minutes per night and as a share of time in bed, with the typical healthy range for each."
+          />
+          <CardContent>
+            <StageComposition stages={stages} />
+          </CardContent>
+        </Card>
+
+        <SleepStagesChart data={data} />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <ChartHeader
+            icon={Clock}
+            iconClass="text-chart-5"
+            title="Sleep schedule"
+            description="When you fell asleep and woke each night"
+            info="Your bedtime and wake-up time for each night, plotted on one continuous evening-to-morning axis. The gap between the two lines is how long you slept; flat, parallel lines mean a consistent routine."
+          />
+          <CardContent>
+            <TrendChart
+              data={schedule}
+              height={260}
+              valueFormatter={clockFromNoonHours}
+              series={[
+                { key: "bedtime", label: "Bedtime", type: "line", color: "var(--chart-5)" },
+                { key: "wake", label: "Wake-up", type: "line", color: "var(--chart-3)" },
+              ]}
+            />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <ChartHeader
+            icon={CalendarDays}
+            iconClass="text-chart-2"
+            title="By day of week"
+            description="Average hours asleep · spot weekend catch-up"
+            info="Average hours asleep grouped by the day of the week the night began. Taller weekend bars suggest you're catching up on sleep debt built up during the week."
+          />
+          <CardContent>
+            <TrendChart
+              data={weekday.map((w) => ({ day: w.day, hours: w.hours }))}
+              xKey="day"
+              height={260}
+              valueFormatter={(v) => `${v.toFixed(1)}h`}
+              series={[{ key: "hours", label: "Avg asleep", type: "bar", color: "var(--chart-2)" }]}
+            />
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Sleep & recovery vitals</CardTitle>
+          <CardDescription>
+            Per-night sleep quality alongside the physiology measured overnight.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ConfigurableTrendChart
+            metrics={vitals}
+            defaultType="line"
+            height={280}
+            info="Pick a metric to chart over the selected range. Per-night sleep efficiency and time asleep sit alongside the physiology measured while you slept — wrist temperature, respiratory rate, blood oxygen, resting heart rate and HRV — so you can eyeball how they move together."
+          />
+        </CardContent>
+      </Card>
+
+      <RecentNights sessions={sessions} />
+    </div>
+  );
+}
+
+interface StageInfo {
+  blurb: string;
+  /** Typical share of the night for a healthy adult, as a 0–100 range. */
+  typical: [number, number];
+  typicalLabel: string;
+}
+
+const STAGE_INFO: Record<StageStat["key"], StageInfo> = {
+  deep: {
+    blurb:
+      "The most physically restorative stage — the body repairs tissue, builds muscle and bone, and consolidates the immune system. Hardest to wake from.",
+    typical: [13, 23],
+    typicalLabel: "13–23%",
+  },
+  rem: {
+    blurb:
+      "Dreaming sleep. Consolidates memory, supports learning and creativity, and helps regulate mood. Concentrated in the second half of the night.",
+    typical: [20, 25],
+    typicalLabel: "20–25%",
+  },
+  light: {
+    blurb:
+      "The bulk of the night. Bridges the deeper stages, relaxes muscles and slows the heart, and still contributes to memory and recovery.",
+    typical: [45, 55],
+    typicalLabel: "45–55%",
+  },
+  awake: {
+    blurb:
+      "Brief awakenings after first falling asleep. A small amount is completely normal; a high share can point to fragmented, restless sleep.",
+    typical: [0, 10],
+    typicalLabel: "under 10%",
+  },
+};
+
+function SleepStagesChart({ data }: { data: Array<Record<string, number | null | string>> }) {
+  const [type, setType] = useState<ChartType>("area");
+  return (
+    <Card className="flex flex-col lg:col-span-2">
+      <ChartHeader
+        title="Sleep stages"
+        info="Each night's sleep split into deep, REM, light and awake minutes, stacked so the full height is the total time tracked. Switch between area, bar and line views with the toggle."
+        actions={<ChartTypeToggle value={type} onChange={setType} />}
+      />
+      <CardContent className="flex min-h-[320px] flex-1 flex-col">
+        <TrendChart
+          data={data}
+          height="100%"
+          valueFormatter={(v) => `${Math.round(v / 60)}h`}
+          series={[
+            { key: "deep", label: "Deep", color: "var(--chart-5)", type, stackId: "s" },
+            { key: "rem", label: "REM", color: "var(--chart-3)", type, stackId: "s" },
+            { key: "light", label: "Light", color: "var(--chart-2)", type, stackId: "s" },
+            { key: "awake", label: "Awake", color: "var(--chart-4)", type, stackId: "s" },
+          ]}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * A single-element segmented bar via a hard-stop linear gradient. Avoids the
+ * hairline anti-alias seams you get between fractional-width flex children, and
+ * keeps every segment perfectly flush and full-height. Returns undefined when
+ * there's nothing to show so the caller can fall back to the muted track.
+ */
+function barGradient(parts: Array<{ pct: number; color: string }>): string | undefined {
+  const visible = parts.filter((p) => p.pct > 0);
+  if (!visible.length) return undefined;
+  let acc = 0;
+  const stops = visible.map((p) => {
+    const stop = `${p.color} ${acc}% ${acc + p.pct}%`;
+    acc += p.pct;
+    return stop;
+  });
+  return `linear-gradient(90deg, ${stops.join(", ")})`;
+}
+
+function StageComposition({ stages }: { stages: StageStat[] }) {
+  return (
+    <div className="space-y-5">
+      <div className="h-6 w-full rounded-md bg-muted" style={{ background: barGradient(stages) }} />
+      <ul className="space-y-4">
+        {stages.map((s) => {
+          const info = STAGE_INFO[s.key];
+          const inRange = s.pct >= info.typical[0] && s.pct <= info.typical[1];
+          return (
+            <li key={s.key} className="space-y-1.5 border-t pt-3 first:border-t-0 first:pt-0">
+              <div className="flex items-baseline gap-2">
+                <span
+                  className="h-2.5 w-2.5 shrink-0 translate-y-[1px] rounded-full"
+                  style={{ backgroundColor: s.color }}
+                />
+                <span className="font-medium">{s.label}</span>
+                <span className="text-xs text-muted-foreground tabular-nums">
+                  {fmt.duration(s.avgMin)}/night
+                </span>
+                <span className="ml-auto text-lg font-semibold tabular-nums">
+                  {s.pct.toFixed(0)}%
+                </span>
+              </div>
+              <p className="text-xs leading-relaxed text-muted-foreground">{info.blurb}</p>
+              <p className="text-xs">
+                <span className="text-muted-foreground">Typical {info.typicalLabel} · </span>
+                <span className={inRange ? "text-emerald-500" : "text-amber-500"}>
+                  {inRange ? "in range" : "outside range"}
+                </span>
+              </p>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+function RecentNights({ sessions }: { sessions: SleepSession[] }) {
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(25);
+
+  // Most-recent first.
+  const ordered = useMemo(() => sessions.slice().reverse(), [sessions]);
+  const total = ordered.length;
+  const rows = ordered.slice(page * pageSize, page * pageSize + pageSize);
+
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader>
+        <CardTitle className="text-base">Recent nights</CardTitle>
+        <CardDescription>Every recorded night in this range</CardDescription>
+      </CardHeader>
+      <CardContent className="px-0">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th className="px-6 py-2 font-medium">Night</th>
+                <th className="px-3 py-2 font-medium">Bedtime</th>
+                <th className="px-3 py-2 font-medium">Wake</th>
+                <th className="px-3 py-2 text-right font-medium">Asleep</th>
+                <th className="px-3 py-2 text-right font-medium">Efficiency</th>
+                <th className="px-6 py-2 font-medium">Stages</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((s) => {
+                const eff = efficiencyPct(s);
+                return (
+                  <tr key={s.id} className="border-b last:border-0 hover:bg-accent/40">
+                    <td className="whitespace-nowrap px-6 py-2.5 font-medium">
+                      {fmt.shortDate(s.start_time)}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2.5 tabular-nums text-muted-foreground">
+                      {fmt.timeOfDay(s.start_time)}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2.5 tabular-nums text-muted-foreground">
+                      {s.end_time ? fmt.timeOfDay(s.end_time) : "—"}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2.5 text-right tabular-nums">
+                      {fmt.duration(s.duration_min)}
+                    </td>
+                    <td className="whitespace-nowrap px-3 py-2.5 text-right tabular-nums">
+                      {eff != null ? `${eff.toFixed(0)}%` : "—"}
+                    </td>
+                    <td className="px-6 py-2.5">
+                      <StageBar session={s} />
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+        <TablePagination
+          page={page}
+          pageSize={pageSize}
+          total={total}
+          onPageChange={setPage}
+          onPageSizeChange={(s) => {
+            setPageSize(s);
+            setPage(0);
+          }}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+function StageBar({ session }: { session: SleepSession }) {
+  const segs = [
+    { min: session.deep_min ?? 0, color: "var(--chart-5)" },
+    { min: session.rem_min ?? 0, color: "var(--chart-3)" },
+    { min: session.light_min ?? 0, color: "var(--chart-2)" },
+    { min: session.awake_min ?? 0, color: "var(--chart-4)" },
+  ];
+  const total = segs.reduce((sum, s) => sum + s.min, 0);
+  if (total === 0) return <span className="text-xs text-muted-foreground">—</span>;
+  const parts = segs.map((s) => ({ pct: (s.min / total) * 100, color: s.color }));
+  return (
+    <div
+      className="h-2 w-full rounded-full bg-muted"
+      style={{ background: barGradient(parts) }}
+    />
   );
 }

--- a/app/workouts/[id]/page.tsx
+++ b/app/workouts/[id]/page.tsx
@@ -6,6 +6,7 @@ import dynamic from "next/dynamic";
 import { ArrowLeft, Flame, MapPin, Route, Thermometer, Timer } from "lucide-react";
 import { useWorkout, useWorkoutRoute } from "@/lib/queries/workouts";
 import { PageHeader } from "@/components/dashboard/page-header";
+import { ChartHeader } from "@/components/dashboard/chart-header";
 import { ChartSkeleton, ErrorState } from "@/components/dashboard/states";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -68,9 +69,10 @@ export default function WorkoutDetailPage() {
 
           <div className="grid gap-6 lg:grid-cols-3">
             <Card className="lg:col-span-2">
-              <CardHeader>
-                <CardTitle className="text-base">Route</CardTitle>
-              </CardHeader>
+              <ChartHeader
+                title="Route"
+                info="The GPS track recorded for this workout, drawn on a map. Only outdoor sessions with location data have a route; indoor workouts won't show one."
+              />
               <CardContent>
                 {route.isPending ? (
                   <ChartSkeleton className="h-[360px]" />

--- a/app/workouts/page.tsx
+++ b/app/workouts/page.tsx
@@ -316,6 +316,7 @@ export default function WorkoutsPage() {
               metrics={chartMetrics}
               defaultMetric="calories"
               defaultType="bar"
+              info="Your workouts aggregated per day for the chosen metric — calories, distance, duration, session count or average heart rate. Use the dropdown to switch metric and the toggle for bar, line or area. Honours the filters applied below."
             />
 
             <Card>

--- a/components/charts/configurable-trend-chart.tsx
+++ b/components/charts/configurable-trend-chart.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/select";
 import { TrendChart } from "./trend-chart";
 import { ChartTypeToggle, type ChartType } from "./chart-type-toggle";
+import { InfoHint } from "@/components/dashboard/info-hint";
 
 export interface ChartMetric {
   key: string;
@@ -35,12 +36,15 @@ export function ConfigurableTrendChart({
   defaultMetric,
   defaultType = "bar",
   height,
+  info,
 }: {
   metrics: ChartMetric[];
   title?: string;
   defaultMetric?: string;
   defaultType?: ChartType;
   height?: number;
+  /** Optional explainer shown via an info icon in the header. */
+  info?: string;
 }) {
   const [metricKey, setMetricKey] = useState(defaultMetric ?? metrics[0]?.key);
   const [type, setType] = useState<ChartType>(defaultType);
@@ -81,6 +85,7 @@ export function ConfigurableTrendChart({
             </SelectContent>
           </Select>
           <ChartTypeToggle value={type} onChange={setType} />
+          {info && <InfoHint text={info} />}
         </div>
       </CardHeader>
       <CardContent>

--- a/components/charts/trend-chart.tsx
+++ b/components/charts/trend-chart.tsx
@@ -41,7 +41,8 @@ export function TrendChart({
   data: Array<Record<string, number | null | string>>;
   series: SeriesDef[];
   xKey?: string;
-  height?: number;
+  /** Pixel height, or a percentage (e.g. "100%") to fill a flex container. */
+  height?: number | `${number}%`;
   yWidth?: number;
   valueFormatter?: (value: number) => string;
   /** Unit appended to Y-axis ticks. Defaults to the sole series' unit. */

--- a/components/dashboard/chart-header.tsx
+++ b/components/dashboard/chart-header.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { InfoHint } from "@/components/dashboard/info-hint";
+
+/**
+ * A chart card header: title (with optional icon) + description on the left,
+ * any controls plus an info icon pinned to the top-right. The info icon reveals
+ * a tooltip explaining what the chart shows. Shared by every graph card.
+ */
+export function ChartHeader({
+  icon: Icon,
+  iconClass,
+  title,
+  description,
+  info,
+  actions,
+}: {
+  icon?: LucideIcon;
+  iconClass?: string;
+  title: string;
+  description?: string;
+  info: string;
+  /** Optional controls (e.g. a chart-type toggle) shown left of the info icon. */
+  actions?: ReactNode;
+}) {
+  return (
+    <CardHeader className="flex flex-row items-start justify-between gap-3 space-y-0">
+      <div className="space-y-1.5">
+        <CardTitle className="flex items-center gap-2 text-base">
+          {Icon && <Icon className={cn("h-4 w-4", iconClass)} />}
+          {title}
+        </CardTitle>
+        {description && <CardDescription>{description}</CardDescription>}
+      </div>
+      <div className="flex shrink-0 items-center gap-2">
+        {actions}
+        <InfoHint text={info} />
+      </div>
+    </CardHeader>
+  );
+}

--- a/components/dashboard/info-hint.tsx
+++ b/components/dashboard/info-hint.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { Info } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+/** A small info icon that reveals an explanatory tooltip — for chart headers. */
+export function InfoHint({ text }: { text: string }) {
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          aria-label="About this chart"
+          className="shrink-0 rounded-full text-muted-foreground/60 transition-colors hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          <Info className="h-4 w-4" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent>{text}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/components/ui/tooltip.tsx
+++ b/components/ui/tooltip.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import * as React from "react";
+import { Tooltip as TooltipPrimitive } from "radix-ui";
+
+import { cn } from "@/lib/utils";
+
+function TooltipProvider({
+  delayDuration = 150,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  );
+}
+
+function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  );
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />;
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 6,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 max-w-xs rounded-md border bg-popover px-3 py-1.5 text-xs leading-relaxed text-popover-foreground shadow-md",
+          "animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+          "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          className,
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="-my-px fill-popover drop-shadow-[0_1px_0_var(--border)]" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  );
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/lib/__tests__/sleep.test.ts
+++ b/lib/__tests__/sleep.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  circularTimeStats,
+  clockFromNoonHours,
+  clockLabel,
+  efficiencyPct,
+  hoursSinceAnchorNoon,
+  minutesIntoDay,
+  stageBreakdown,
+  weekdayAverages,
+  type SleepLike,
+} from "../sleep";
+
+/** Local (no trailing Z) ISO so wall-clock getters are timezone-independent. */
+const at = (s: string) => s;
+
+function session(over: Partial<SleepLike> = {}): SleepLike {
+  return {
+    start_time: at("2024-06-01T23:00:00"),
+    end_time: at("2024-06-02T07:00:00"),
+    duration_min: 420,
+    quality_pct: 90,
+    awake_min: 30,
+    rem_min: 90,
+    light_min: 240,
+    deep_min: 90,
+    ...over,
+  };
+}
+
+describe("minutesIntoDay / clockLabel", () => {
+  it("reads local wall-clock minutes", () => {
+    expect(minutesIntoDay(at("2024-06-01T23:30:00"))).toBe(23 * 60 + 30);
+    expect(minutesIntoDay(at("2024-06-02T00:15:00"))).toBe(15);
+  });
+
+  it("formats and wraps minutes past midnight", () => {
+    expect(clockLabel(23 * 60 + 34)).toBe("23:34");
+    expect(clockLabel(5)).toBe("00:05");
+    expect(clockLabel(1440)).toBe("00:00");
+    expect(clockLabel(null)).toBe("—");
+  });
+});
+
+describe("circularTimeStats", () => {
+  it("averages across midnight rather than to noon", () => {
+    const { mean } = circularTimeStats([23 * 60 + 30, 30]); // 23:30 & 00:30
+    expect(mean).toBeCloseTo(0, 5); // midnight
+  });
+
+  it("a perfectly regular schedule has ~zero spread", () => {
+    const { mean, stdev } = circularTimeStats([1380, 1380, 1380]);
+    expect(mean).toBeCloseTo(1380, 5);
+    expect(stdev).toBeCloseTo(0, 5);
+  });
+
+  it("returns nulls when empty", () => {
+    expect(circularTimeStats([null, undefined])).toEqual({ mean: null, stdev: null });
+  });
+});
+
+describe("efficiencyPct", () => {
+  it("prefers the stored quality", () => {
+    expect(efficiencyPct(session({ quality_pct: 88 }))).toBe(88);
+  });
+
+  it("falls back to asleep / in-bed", () => {
+    expect(efficiencyPct(session({ quality_pct: null, duration_min: 450, awake_min: 50 }))).toBe(90);
+  });
+
+  it("is null with no time in bed", () => {
+    expect(efficiencyPct(session({ quality_pct: null, duration_min: 0, awake_min: 0 }))).toBeNull();
+  });
+});
+
+describe("hoursSinceAnchorNoon / clockFromNoonHours", () => {
+  const anchor = at("2024-06-01T23:00:00");
+
+  it("places an evening bedtime and morning wake on one axis", () => {
+    expect(hoursSinceAnchorNoon(at("2024-06-01T23:00:00"), anchor)).toBeCloseTo(11);
+    expect(hoursSinceAnchorNoon(at("2024-06-02T07:00:00"), anchor)).toBeCloseTo(19);
+  });
+
+  it("handles an after-midnight bedtime via its own anchor", () => {
+    const lateAnchor = at("2024-06-02T01:00:00");
+    expect(hoursSinceAnchorNoon(lateAnchor, lateAnchor)).toBeCloseTo(13);
+  });
+
+  it("round-trips back to a clock label", () => {
+    expect(clockFromNoonHours(11)).toBe("23:00");
+    expect(clockFromNoonHours(19)).toBe("07:00");
+    expect(clockFromNoonHours(13)).toBe("01:00");
+  });
+});
+
+describe("stageBreakdown", () => {
+  it("averages each stage and shares sum to 100", () => {
+    const { stages, totalMin } = stageBreakdown([
+      session({ deep_min: 60, rem_min: 60, light_min: 240, awake_min: 40 }),
+      session({ deep_min: 100, rem_min: 100, light_min: 200, awake_min: 0 }),
+    ]);
+    expect(totalMin).toBeCloseTo(80 + 80 + 220 + 20);
+    const deep = stages.find((s) => s.key === "deep")!;
+    expect(deep.avgMin).toBeCloseTo(80);
+    expect(stages.reduce((s, x) => s + x.pct, 0)).toBeCloseTo(100);
+  });
+
+  it("is safe on an empty set", () => {
+    const { stages, totalMin } = stageBreakdown([]);
+    expect(totalMin).toBe(0);
+    expect(stages.every((s) => s.pct === 0)).toBe(true);
+  });
+});
+
+describe("weekdayAverages", () => {
+  it("buckets nights Mon-first by the day they began", () => {
+    // 2024-06-01 is a Saturday, 2024-06-03 a Monday.
+    const rows = weekdayAverages([
+      session({ start_time: at("2024-06-01T23:00:00"), duration_min: 480 }),
+      session({ start_time: at("2024-06-03T23:00:00"), duration_min: 360 }),
+      session({ start_time: at("2024-06-10T23:00:00"), duration_min: 420 }),
+    ]);
+    expect(rows[0]).toMatchObject({ day: "Mon", nights: 2 });
+    expect(rows[0].hours).toBeCloseTo((6 + 7) / 2);
+    expect(rows.find((r) => r.day === "Sat")!.hours).toBeCloseTo(8);
+    expect(rows.find((r) => r.day === "Sun")!.hours).toBeNull();
+  });
+});

--- a/lib/sleep.ts
+++ b/lib/sleep.ts
@@ -1,0 +1,168 @@
+/**
+ * Pure helpers for deriving sleep analytics from `sleep_sessions` rows:
+ * stage composition, sleep efficiency, schedule (bedtime/wake) and how
+ * regular that schedule is. All date maths is local-calendar (see CLAUDE.md):
+ * we read the wall-clock hour/minute of a timestamp, never UTC offsets.
+ */
+import { parseISO } from "date-fns";
+
+const MS_PER_HOUR = 3_600_000;
+const MIN_PER_DAY = 1440;
+
+/** Minimal shape these helpers need — a subset of `SleepSession`. */
+export interface SleepLike {
+  start_time: string;
+  end_time: string | null;
+  duration_min: number | null;
+  quality_pct: number | null;
+  awake_min: number | null;
+  rem_min: number | null;
+  light_min: number | null;
+  deep_min: number | null;
+}
+
+/** Local minutes past midnight for an ISO timestamp (0–1439). */
+export function minutesIntoDay(iso: string): number {
+  const d = parseISO(iso);
+  return d.getHours() * 60 + d.getMinutes();
+}
+
+/** "23:34" from minutes past midnight; wraps modulo 24h. `null` → "—". */
+export function clockLabel(minutes: number | null | undefined): string {
+  if (minutes == null || !Number.isFinite(minutes)) return "—";
+  const m = ((Math.round(minutes) % MIN_PER_DAY) + MIN_PER_DAY) % MIN_PER_DAY;
+  const h = Math.floor(m / 60);
+  return `${String(h).padStart(2, "0")}:${String(m % 60).padStart(2, "0")}`;
+}
+
+export interface CircularTime {
+  /** Mean time-of-day in minutes past midnight, or null when no input. */
+  mean: number | null;
+  /** Circular std-dev in minutes — schedule regularity (lower = steadier). */
+  stdev: number | null;
+}
+
+/**
+ * Average a set of times-of-day (minutes past midnight) on the 24h circle, so
+ * 23:30 and 00:30 average to midnight rather than to noon. Also returns the
+ * circular standard deviation, a "how regular is bedtime" measure in minutes.
+ */
+export function circularTimeStats(times: Array<number | null | undefined>): CircularTime {
+  const mins = times.filter((t): t is number => t != null && Number.isFinite(t));
+  if (!mins.length) return { mean: null, stdev: null };
+
+  let sumSin = 0;
+  let sumCos = 0;
+  for (const t of mins) {
+    const a = (t / MIN_PER_DAY) * 2 * Math.PI;
+    sumSin += Math.sin(a);
+    sumCos += Math.cos(a);
+  }
+  const meanSin = sumSin / mins.length;
+  const meanCos = sumCos / mins.length;
+
+  const raw = (Math.atan2(meanSin, meanCos) / (2 * Math.PI)) * MIN_PER_DAY;
+  const mean = ((raw % MIN_PER_DAY) + MIN_PER_DAY) % MIN_PER_DAY;
+
+  const r = Math.sqrt(meanSin ** 2 + meanCos ** 2);
+  const stdev = r > 0 ? (Math.sqrt(-2 * Math.log(r)) / (2 * Math.PI)) * MIN_PER_DAY : null;
+
+  return { mean, stdev };
+}
+
+/**
+ * Sleep efficiency: time asleep as a fraction of time in bed. Prefers the
+ * ingest's `quality_pct` (computed against in-bed time when available) and
+ * falls back to asleep / (asleep + awake).
+ */
+export function efficiencyPct(s: SleepLike): number | null {
+  if (s.quality_pct != null) return s.quality_pct;
+  const asleep = s.duration_min ?? 0;
+  const inBed = asleep + (s.awake_min ?? 0);
+  return inBed > 0 ? (asleep / inBed) * 100 : null;
+}
+
+/**
+ * Hours elapsed since the "anchor noon" — noon of the day the night began. A
+ * bedtime of 23:00 → 11, an after-midnight 01:00 → 13, a 07:00 wake → 19. This
+ * lays an evening→morning night onto one continuous, monotonic axis so bedtime
+ * and wake-up can be plotted as two drifting lines. Pass the session's
+ * `start_time` as `anchorIso` for both bedtime and wake so they share a night.
+ */
+export function hoursSinceAnchorNoon(iso: string, anchorIso: string): number {
+  const t = parseISO(iso).getTime();
+  const anchor = parseISO(anchorIso);
+  const wasMorning = anchor.getHours() < 12;
+  anchor.setHours(12, 0, 0, 0);
+  if (wasMorning) anchor.setDate(anchor.getDate() - 1);
+  return (t - anchor.getTime()) / MS_PER_HOUR;
+}
+
+/** Inverse of {@link hoursSinceAnchorNoon} for axis ticks: hours → "HH:MM". */
+export function clockFromNoonHours(hours: number): string {
+  return clockLabel(720 + hours * 60);
+}
+
+export interface StageStat {
+  key: "deep" | "rem" | "light" | "awake";
+  label: string;
+  color: string;
+  /** Mean minutes per night across the supplied sessions. */
+  avgMin: number;
+  /** Share of the average night (0–100). */
+  pct: number;
+}
+
+const STAGES: Array<{ key: StageStat["key"]; label: string; color: string; field: keyof SleepLike }> = [
+  { key: "deep", label: "Deep", color: "var(--chart-5)", field: "deep_min" },
+  { key: "rem", label: "REM", color: "var(--chart-3)", field: "rem_min" },
+  { key: "light", label: "Light", color: "var(--chart-2)", field: "light_min" },
+  { key: "awake", label: "Awake", color: "var(--chart-4)", field: "awake_min" },
+];
+
+/** Average minutes and share of each stage across the supplied sessions. */
+export function stageBreakdown(sessions: SleepLike[]): { stages: StageStat[]; totalMin: number } {
+  const n = sessions.length || 1;
+  const avgs = STAGES.map((s) => ({
+    ...s,
+    avgMin: sessions.reduce((sum, x) => sum + ((x[s.field] as number | null) ?? 0), 0) / n,
+  }));
+  const total = avgs.reduce((sum, s) => sum + s.avgMin, 0);
+  const stages: StageStat[] = avgs.map((s) => ({
+    key: s.key,
+    label: s.label,
+    color: s.color,
+    avgMin: s.avgMin,
+    pct: total > 0 ? (s.avgMin / total) * 100 : 0,
+  }));
+  return { stages, totalMin: total };
+}
+
+const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
+
+export interface WeekdayStat {
+  day: string;
+  /** Mean hours asleep on this weekday, or null if no nights recorded. */
+  hours: number | null;
+  nights: number;
+}
+
+/**
+ * Average hours asleep grouped by day of week (Mon-first), keyed by the local
+ * calendar day the night began. Surfaces patterns like weekend catch-up sleep.
+ */
+export function weekdayAverages(sessions: SleepLike[]): WeekdayStat[] {
+  const buckets = WEEKDAYS.map(() => ({ sum: 0, n: 0 }));
+  for (const s of sessions) {
+    if (s.duration_min == null) continue;
+    // JS getDay(): 0=Sun..6=Sat → Mon-first index.
+    const idx = (parseISO(s.start_time).getDay() + 6) % 7;
+    buckets[idx].sum += s.duration_min / 60;
+    buckets[idx].n += 1;
+  }
+  return WEEKDAYS.map((day, i) => ({
+    day,
+    hours: buckets[i].n ? buckets[i].sum / buckets[i].n : null,
+    nights: buckets[i].n,
+  }));
+}


### PR DESCRIPTION
## Summary

Two pieces of work, built up over several iterations on the Sleep page and then generalised across the app.

### Sleep page — more detail, more polish
- New sections: **stage composition** breakdown, **sleep schedule** (bedtime vs wake on one continuous axis), **by day of week** averages, **sleep & recovery vitals** chart, and a paginated **recent nights** table.
- Richer stat cards: avg time asleep, efficiency, and avg bedtime/wake with a circular-stats **consistency** figure.
- Stage/efficiency bars render as **seam-free CSS gradients** (fixes hairline anti-alias gaps between segments).
- The **Sleep stages** chart now fills its card and has a bar/line/area toggle.
- New pure, unit-tested helpers in `lib/sleep.ts` (circular time stats, sleep efficiency, schedule-axis transform, stage breakdown, weekday averages) with 14 tests in `lib/__tests__/sleep.test.ts`.

### Info icons on every graph
- Added an **info icon with an explanatory tooltip** to the top-right of every graph across all pages (overview, activity, body, mobility, nutrition, hearing, heart, sleep, workouts, map, and the ECG / workout detail pages).
- Introduced a shared `ChartHeader` + `InfoHint` and a shadcn-style `tooltip` primitive; `ConfigurableTrendChart` gained an `info` prop.
- `TrendChart` now accepts a percentage height so it can fill flex containers.

Pages with no actual graphs (Insights, Records) were intentionally left untouched.

## Testing
- `npm run typecheck` — pass
- `npm run lint` — pass
- `npm run test` — 87 tests pass
- Manually verified every route in the browser preview: info-icon counts match expectations, tooltips render with the correct text, and the detail pages render without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)