### PR TITLE
Richer activity dashboard

### DIFF
--- a/app/activity/page.tsx
+++ b/app/activity/page.tsx
@@ -1,16 +1,32 @@
 "use client";
 
-import { useState } from "react";
-import { Flame, Footprints, Mountain, Route } from "lucide-react";
-import { useDailyMetrics } from "@/lib/queries/metrics";
+import { useMemo, useState } from "react";
+import {
+  Footprints,
+  Route,
+  Flame,
+  Mountain,
+  Timer,
+  Bike,
+  HeartPulse,
+  CalendarDays,
+  Activity,
+} from "lucide-react";
+import { useDailyMetrics, type DailyMetric } from "@/lib/queries/metrics";
 import { PageHeader } from "@/components/dashboard/page-header";
 import { RangeSelect } from "@/components/dashboard/range-select";
 import { StatCard } from "@/components/dashboard/stat-card";
-import { StyleableTrendChart } from "@/components/charts/styleable-trend-chart";
+import { TrendChart } from "@/components/charts/trend-chart";
+import { ConfigurableTrendChart, type ChartMetric } from "@/components/charts/configurable-trend-chart";
+import { ChartTypeToggle, type ChartType } from "@/components/charts/chart-type-toggle";
+import { TablePagination } from "@/components/dashboard/table-pagination";
+import { ChartHeader } from "@/components/dashboard/chart-header";
 import { CardGridSkeleton, ChartSkeleton, QueryView } from "@/components/dashboard/states";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import type { RangeKey } from "@/lib/queries/ranges";
 import * as fmt from "@/lib/format";
 import { mean, sum, deltaPct } from "@/lib/stats";
+import { energyComposition, weekdayAverages, type EnergyPart } from "@/lib/activity";
 
 export default function ActivityPage() {
   const [range, setRange] = useState<RangeKey>("90d");
@@ -20,7 +36,7 @@ export default function ActivityPage() {
     <>
       <PageHeader
         title="Activity & Movement"
-        description="Steps, distance, flights climbed and the energy you burn each day."
+        description="Steps, distance, the energy you burn and how your movement varies day to day."
         actions={<RangeSelect value={range} onChange={setRange} />}
       />
 
@@ -34,42 +50,358 @@ export default function ActivityPage() {
         }
         isEmpty={(d) => d.length === 0}
       >
-        {(m) => (
-          <div className="space-y-6">
-            <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-              <StatCard label="Avg daily steps" value={fmt.number(mean(m.map((d) => d.steps)))} icon={Footprints} accent="text-chart-1" delta={deltaPct(m.map((d) => d.steps), 7)} />
-              <StatCard label="Total distance" value={fmt.number(sum(m.map((d) => d.distance_km)))} unit="km" icon={Route} accent="text-chart-2" />
-              <StatCard label="Avg active energy" value={fmt.number(mean(m.map((d) => d.active_energy)))} unit="kcal" icon={Flame} accent="text-chart-3" delta={deltaPct(m.map((d) => d.active_energy), 7)} />
-              <StatCard label="Flights climbed" value={fmt.number(sum(m.map((d) => d.flights_climbed)))} icon={Mountain} accent="text-chart-5" />
-            </div>
-
-            <StyleableTrendChart
-              title="Daily steps"
-              data={m}
-              defaultType="bar"
-              series={[{ key: "steps", label: "Steps", color: "var(--chart-1)" }]}
-              info="Total steps counted each day by your iPhone and Apple Watch. Bar height is that day's step count over the selected range."
-            />
-
-            <div className="grid gap-6 lg:grid-cols-2">
-              <StyleableTrendChart
-                title="Active energy"
-                data={m}
-                height={260}
-                series={[{ key: "active_energy", label: "Active energy", color: "var(--chart-3)", unit: "kcal" }]}
-                info="Active calories burned per day — energy spent on movement above your resting metabolism, the figure behind the red Move ring."
-              />
-              <StyleableTrendChart
-                title="Distance"
-                data={m}
-                height={260}
-                series={[{ key: "distance_km", label: "Distance", color: "var(--chart-2)", unit: "km" }]}
-                info="Distance travelled on foot each day (walking and running), in kilometres, as tracked by your devices."
-              />
-            </div>
-          </div>
-        )}
+        {(m) => <ActivityDashboard metrics={m} />}
       </QueryView>
     </>
+  );
+}
+
+function ActivityDashboard({ metrics }: { metrics: DailyMetric[] }) {
+  const energy = useMemo(() => energyComposition(metrics), [metrics]);
+
+  // Days where the Apple exercise ring closed (≥30 min brisk activity).
+  const exerciseClosed = useMemo(
+    () => metrics.filter((d) => (d.exercise_min ?? 0) >= 30).length,
+    [metrics],
+  );
+  const totalCycling = useMemo(() => sum(metrics.map((d) => d.distance_cycling_km)), [metrics]);
+  const hasCycling = totalCycling > 0;
+  const hasWalkingHr = useMemo(() => metrics.some((d) => d.walking_hr_avg != null), [metrics]);
+
+  // Average steps grouped by weekday (Mon-first).
+  const stepsByDay = useMemo(
+    () => weekdayAverages(metrics, "steps").map((w) => ({ day: w.day, steps: w.value })),
+    [metrics],
+  );
+
+  // Resting + active burn per day for the stacked energy chart.
+  const burn = useMemo(
+    () =>
+      metrics.map((d) => ({
+        date: String(d.date),
+        resting: d.basal_energy ?? 0,
+        active: d.active_energy ?? 0,
+      })),
+    [metrics],
+  );
+
+  // Per-metric series for the movement-metrics selector.
+  const movement: ChartMetric[] = useMemo(() => {
+    const fromKey = (key: keyof DailyMetric): Array<{ date: string; value: number | null }> =>
+      metrics.map((d) => ({ date: String(d.date), value: (d[key] as number | null) ?? null }));
+    const has = (key: keyof DailyMetric) => metrics.some((d) => d[key] != null);
+
+    const list: ChartMetric[] = [
+      { key: "steps", label: "Steps", color: "var(--chart-1)", icon: Footprints, data: fromKey("steps"), valueFormatter: (v) => fmt.compactNumber(v) },
+      { key: "distance_km", label: "Distance", unit: "km", color: "var(--chart-2)", icon: Route, data: fromKey("distance_km"), valueFormatter: (v) => v.toFixed(1) },
+      { key: "active_energy", label: "Active energy", unit: "kcal", color: "var(--chart-3)", icon: Flame, data: fromKey("active_energy"), valueFormatter: (v) => v.toFixed(0) },
+      { key: "exercise_min", label: "Exercise minutes", unit: "min", color: "var(--workout)", icon: Timer, data: fromKey("exercise_min"), valueFormatter: (v) => v.toFixed(0) },
+      { key: "flights_climbed", label: "Flights climbed", color: "var(--chart-5)", icon: Mountain, data: fromKey("flights_climbed"), valueFormatter: (v) => v.toFixed(0) },
+    ];
+    if (has("stand_hours"))
+      list.push({ key: "stand_hours", label: "Stand hours", unit: "h", color: "var(--chart-2)", icon: Activity, data: fromKey("stand_hours"), valueFormatter: (v) => v.toFixed(0) });
+    if (hasCycling)
+      list.push({ key: "distance_cycling_km", label: "Cycling distance", unit: "km", color: "var(--chart-4)", icon: Bike, data: fromKey("distance_cycling_km"), valueFormatter: (v) => v.toFixed(1) });
+    if (hasWalkingHr)
+      list.push({ key: "walking_hr_avg", label: "Walking heart rate", unit: "bpm", color: "var(--chart-4)", icon: HeartPulse, data: fromKey("walking_hr_avg"), valueFormatter: (v) => v.toFixed(0) });
+    return list;
+  }, [metrics, hasCycling, hasWalkingHr]);
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          label="Avg daily steps"
+          value={fmt.number(mean(metrics.map((d) => d.steps)))}
+          icon={Footprints}
+          accent="text-chart-1"
+          delta={deltaPct(metrics.map((d) => d.steps), 7)}
+          spark={{ data: metrics, dataKey: "steps", color: "var(--chart-1)" }}
+          sub={`${fmt.compactNumber(sum(metrics.map((d) => d.steps)))} total`}
+        />
+        <StatCard
+          label="Avg active energy"
+          value={fmt.number(mean(metrics.map((d) => d.active_energy)))}
+          unit="kcal"
+          icon={Flame}
+          accent="text-chart-3"
+          delta={deltaPct(metrics.map((d) => d.active_energy), 7)}
+          spark={{ data: metrics, dataKey: "active_energy", color: "var(--chart-3)" }}
+        />
+        <StatCard
+          label="Avg exercise"
+          value={fmt.number(mean(metrics.map((d) => d.exercise_min)))}
+          unit="min"
+          icon={Timer}
+          accent="text-[color:var(--workout)]"
+          delta={deltaPct(metrics.map((d) => d.exercise_min), 7)}
+          spark={{ data: metrics, dataKey: "exercise_min", color: "var(--workout)" }}
+          sub={`${exerciseClosed}/${metrics.length} days ≥30m`}
+        />
+        <StatCard
+          label="Total distance"
+          value={fmt.number(sum(metrics.map((d) => d.distance_km)))}
+          unit="km"
+          icon={Route}
+          accent="text-chart-2"
+          spark={{ data: metrics, dataKey: "distance_km", color: "var(--chart-2)" }}
+          sub={hasCycling ? `+${fmt.number(totalCycling)} km cycling` : undefined}
+        />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <Card>
+          <ChartHeader
+            icon={Flame}
+            iconClass="text-chart-3"
+            title="Energy composition"
+            description={
+              energy.hasResting
+                ? `Average day · ${fmt.number(energy.totalKcal)} kcal burned`
+                : "Average day · active calories only"
+            }
+            info="How the calories you burn on an average day split between resting (basal) energy — what your body uses just staying alive — and active energy from movement. Shown as kcal per day and as a share of total burn."
+          />
+          <CardContent>
+            <EnergyCompositionView energy={energy} />
+          </CardContent>
+        </Card>
+
+        <StepsChart data={metrics} />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <Card>
+          <ChartHeader
+            icon={CalendarDays}
+            iconClass="text-chart-1"
+            title="Steps by day of week"
+            description="Average steps · spot your most active days"
+            info="Average daily steps grouped by the day of the week. Surfaces routine patterns — a quieter desk-bound midweek, or busier, more active weekends."
+          />
+          <CardContent>
+            <TrendChart
+              data={stepsByDay}
+              xKey="day"
+              height={260}
+              valueFormatter={(v) => fmt.compactNumber(v)}
+              series={[{ key: "steps", label: "Avg steps", type: "bar", color: "var(--chart-1)" }]}
+            />
+          </CardContent>
+        </Card>
+
+        <Card>
+          <ChartHeader
+            icon={Flame}
+            iconClass="text-chart-3"
+            title="Daily energy burn"
+            description="Resting + active calories each day"
+            info="Total calories burned each day, stacked into resting (basal) energy and the active energy you add through movement. The full height is your total daily burn."
+          />
+          <CardContent>
+            <TrendChart
+              data={burn}
+              height={260}
+              valueFormatter={(v) => `${fmt.compactNumber(v)}`}
+              series={[
+                ...(energy.hasResting
+                  ? [{ key: "resting", label: "Resting", type: "area" as const, color: "var(--chart-4)", stackId: "e", unit: "kcal" }]
+                  : []),
+                { key: "active", label: "Active", type: "area", color: "var(--chart-3)", stackId: "e", unit: "kcal" },
+              ]}
+            />
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Movement metrics</CardTitle>
+          <CardDescription>
+            Pick a metric to chart over the selected range.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <ConfigurableTrendChart
+            metrics={movement}
+            defaultType="bar"
+            height={280}
+            info="Switch between every movement metric your devices record — steps, distance, active energy, exercise minutes, flights climbed and more — and toggle between bar, line and area views."
+          />
+        </CardContent>
+      </Card>
+
+      <RecentDays metrics={metrics} />
+    </div>
+  );
+}
+
+interface EnergyInfo {
+  blurb: string;
+}
+
+const ENERGY_INFO: Record<EnergyPart["key"], EnergyInfo> = {
+  resting: {
+    blurb:
+      "Basal energy — the calories your body burns at rest just to keep you alive: breathing, circulation and organ function. It scales with body size and is usually the larger share of the day.",
+  },
+  active: {
+    blurb:
+      "The calories you burn through movement on top of resting — every step, workout and bit of fidgeting. This is the figure behind the red Move ring.",
+  },
+};
+
+/**
+ * A single-element segmented bar via a hard-stop linear gradient — avoids the
+ * hairline seams you get between fractional-width flex children. Returns
+ * undefined when there's nothing to show so the caller can fall back to the
+ * muted track. (Mirrors the Sleep page's stage-composition bar.)
+ */
+function barGradient(parts: Array<{ pct: number; color: string }>): string | undefined {
+  const visible = parts.filter((p) => p.pct > 0);
+  if (!visible.length) return undefined;
+  let acc = 0;
+  const stops = visible.map((p) => {
+    const stop = `${p.color} ${acc}% ${acc + p.pct}%`;
+    acc += p.pct;
+    return stop;
+  });
+  return `linear-gradient(90deg, ${stops.join(", ")})`;
+}
+
+function EnergyCompositionView({ energy }: { energy: ReturnType<typeof energyComposition> }) {
+  const parts = energy.hasResting ? energy.parts : energy.parts.filter((p) => p.key === "active");
+  return (
+    <div className="space-y-5">
+      <div className="h-6 w-full rounded-md bg-muted" style={{ background: barGradient(parts) }} />
+      <ul className="space-y-4">
+        {parts.map((p) => (
+          <li key={p.key} className="space-y-1.5 border-t pt-3 first:border-t-0 first:pt-0">
+            <div className="flex items-baseline gap-2">
+              <span
+                className="h-2.5 w-2.5 shrink-0 translate-y-[1px] rounded-full"
+                style={{ backgroundColor: p.color }}
+              />
+              <span className="font-medium">{p.label}</span>
+              <span className="text-xs text-muted-foreground tabular-nums">
+                {fmt.number(p.avgKcal)} kcal/day
+              </span>
+              <span className="ml-auto text-lg font-semibold tabular-nums">{p.pct.toFixed(0)}%</span>
+            </div>
+            <p className="text-xs leading-relaxed text-muted-foreground">{ENERGY_INFO[p.key].blurb}</p>
+          </li>
+        ))}
+      </ul>
+      {!energy.hasResting && (
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          Resting (basal) energy isn&apos;t recorded in this range, so only active calories are shown.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function StepsChart({ data }: { data: DailyMetric[] }) {
+  const [type, setType] = useState<ChartType>("bar");
+  return (
+    <Card className="flex flex-col lg:col-span-2">
+      <ChartHeader
+        icon={Footprints}
+        iconClass="text-chart-1"
+        title="Daily steps"
+        info="Total steps counted each day by your iPhone and Apple Watch over the selected range. Switch between bar, line and area views with the toggle."
+        actions={<ChartTypeToggle value={type} onChange={setType} />}
+      />
+      <CardContent className="flex min-h-[320px] flex-1 flex-col">
+        <TrendChart
+          data={data}
+          height="100%"
+          valueFormatter={(v) => fmt.compactNumber(v)}
+          series={[{ key: "steps", label: "Steps", color: "var(--chart-1)", type }]}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+function RecentDays({ metrics }: { metrics: DailyMetric[] }) {
+  const [page, setPage] = useState(0);
+  const [pageSize, setPageSize] = useState(25);
+
+  // Most-recent first.
+  const ordered = useMemo(() => metrics.slice().reverse(), [metrics]);
+  const maxSteps = useMemo(() => Math.max(1, ...metrics.map((d) => d.steps ?? 0)), [metrics]);
+  const total = ordered.length;
+  const rows = ordered.slice(page * pageSize, page * pageSize + pageSize);
+
+  return (
+    <Card className="overflow-hidden">
+      <CardHeader>
+        <CardTitle className="text-base">Recent days</CardTitle>
+        <CardDescription>Every recorded day in this range</CardDescription>
+      </CardHeader>
+      <CardContent className="px-0">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead className="border-b text-left text-xs uppercase tracking-wide text-muted-foreground">
+              <tr>
+                <th className="px-6 py-2 font-medium">Day</th>
+                <th className="px-3 py-2 text-right font-medium">Steps</th>
+                <th className="px-3 py-2 text-right font-medium">Distance</th>
+                <th className="px-3 py-2 text-right font-medium">Active</th>
+                <th className="px-3 py-2 text-right font-medium">Exercise</th>
+                <th className="px-3 py-2 text-right font-medium">Flights</th>
+                <th className="px-6 py-2 font-medium">Steps vs best</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((d) => (
+                <tr key={String(d.date)} className="border-b last:border-0 hover:bg-accent/40">
+                  <td className="whitespace-nowrap px-6 py-2.5 font-medium">{fmt.shortDate(d.date)}</td>
+                  <td className="whitespace-nowrap px-3 py-2.5 text-right tabular-nums">
+                    {d.steps != null ? fmt.number(d.steps) : "—"}
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-2.5 text-right tabular-nums">
+                    {d.distance_km != null ? `${fmt.number(d.distance_km, 1)} km` : "—"}
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-2.5 text-right tabular-nums">
+                    {d.active_energy != null ? `${fmt.number(d.active_energy)} kcal` : "—"}
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-2.5 text-right tabular-nums">
+                    {d.exercise_min != null ? `${fmt.number(d.exercise_min)} min` : "—"}
+                  </td>
+                  <td className="whitespace-nowrap px-3 py-2.5 text-right tabular-nums">
+                    {d.flights_climbed != null ? fmt.number(d.flights_climbed) : "—"}
+                  </td>
+                  <td className="px-6 py-2.5">
+                    <IntensityBar value={d.steps ?? 0} max={maxSteps} />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <TablePagination
+          page={page}
+          pageSize={pageSize}
+          total={total}
+          onPageChange={setPage}
+          onPageSizeChange={(s) => {
+            setPageSize(s);
+            setPage(0);
+          }}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+function IntensityBar({ value, max }: { value: number; max: number }) {
+  const pct = Math.max(0, Math.min(100, (value / max) * 100));
+  if (value <= 0) return <span className="text-xs text-muted-foreground">—</span>;
+  return (
+    <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+      <div className="h-full rounded-full" style={{ width: `${pct}%`, backgroundColor: "var(--chart-1)" }} />
+    </div>
   );
 }

--- a/lib/__tests__/activity.test.ts
+++ b/lib/__tests__/activity.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest";
+import { energyComposition, weekdayAverages } from "../activity";
+import type { DailyMetric } from "@/lib/queries/metrics";
+
+/** Build a daily_metrics row; only the fields under test need supplying. */
+function day(over: Partial<DailyMetric> = {}): DailyMetric {
+  return { date: "2024-01-01", ...over } as DailyMetric;
+}
+
+describe("weekdayAverages", () => {
+  it("groups a numeric metric by local weekday, Mon-first", () => {
+    const metrics = [
+      day({ date: "2024-01-01", steps: 100 }), // Monday
+      day({ date: "2024-01-08", steps: 200 }), // Monday
+      day({ date: "2024-01-06", steps: 50 }), //  Saturday
+    ];
+    const wk = weekdayAverages(metrics, "steps");
+    expect(wk.map((w) => w.day)).toEqual(["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]);
+    expect(wk[0]).toMatchObject({ day: "Mon", value: 150, days: 2 });
+    expect(wk[5]).toMatchObject({ day: "Sat", value: 50, days: 1 });
+    expect(wk[1]).toMatchObject({ day: "Tue", value: null, days: 0 });
+  });
+
+  it("skips null / non-finite values", () => {
+    const metrics = [
+      day({ date: "2024-01-01", steps: null }),
+      day({ date: "2024-01-08", steps: 300 }),
+    ];
+    const wk = weekdayAverages(metrics, "steps");
+    expect(wk[0]).toMatchObject({ value: 300, days: 1 });
+  });
+
+  it("returns all-null buckets for no data", () => {
+    const wk = weekdayAverages([], "steps");
+    expect(wk).toHaveLength(7);
+    expect(wk.every((w) => w.value === null && w.days === 0)).toBe(true);
+  });
+});
+
+describe("energyComposition", () => {
+  it("splits the average day into resting and active kcal", () => {
+    const metrics = [
+      day({ active_energy: 400, basal_energy: 1600 }),
+      day({ active_energy: 600, basal_energy: 1400 }),
+    ];
+    const { parts, totalKcal, hasResting } = energyComposition(metrics);
+    expect(hasResting).toBe(true);
+    expect(totalKcal).toBe(2000); // 500 active + 1500 resting
+    const resting = parts.find((p) => p.key === "resting")!;
+    const active = parts.find((p) => p.key === "active")!;
+    expect(resting.avgKcal).toBe(1500);
+    expect(active.avgKcal).toBe(500);
+    expect(resting.pct).toBe(75);
+    expect(active.pct).toBe(25);
+    // Resting is ordered first so a gradient bar reads base-then-active.
+    expect(parts[0].key).toBe("resting");
+  });
+
+  it("flags missing resting data and attributes the whole bar to active", () => {
+    const metrics = [day({ active_energy: 500, basal_energy: null })];
+    const { parts, hasResting, totalKcal } = energyComposition(metrics);
+    expect(hasResting).toBe(false);
+    expect(totalKcal).toBe(500);
+    expect(parts.find((p) => p.key === "active")!.pct).toBe(100);
+    expect(parts.find((p) => p.key === "resting")!.pct).toBe(0);
+  });
+
+  it("handles no data without dividing by zero", () => {
+    const { parts, totalKcal } = energyComposition([]);
+    expect(totalKcal).toBe(0);
+    expect(parts.every((p) => p.pct === 0 && p.avgKcal === 0)).toBe(true);
+  });
+});

--- a/lib/activity.ts
+++ b/lib/activity.ts
@@ -1,0 +1,82 @@
+/**
+ * Pure helpers for the Activity dashboard: how each day's energy splits into
+ * resting vs active burn, and how a metric varies by day of week. Date maths is
+ * local-calendar (see CLAUDE.md) — `daily_metrics.date` is a local `yyyy-MM-dd`
+ * key, so we parse it as local time and never touch UTC offsets.
+ */
+import { parseISO } from "date-fns";
+import { mean } from "@/lib/stats";
+import type { DailyMetric } from "@/lib/queries/metrics";
+
+const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"] as const;
+
+/** Keys of `daily_metrics` whose values are numeric (usable as a series). */
+export type NumericMetricKey = {
+  [K in keyof DailyMetric]: DailyMetric[K] extends number | null ? K : never;
+}[keyof DailyMetric];
+
+export interface WeekdayStat {
+  day: string;
+  /** Mean of the chosen metric on this weekday, or null if no days recorded. */
+  value: number | null;
+  days: number;
+}
+
+/**
+ * Average a numeric daily metric grouped by day of week (Mon-first), keyed by
+ * the local calendar day. Surfaces patterns like quieter weekdays at a desk vs
+ * more active weekends.
+ */
+export function weekdayAverages(metrics: DailyMetric[], key: NumericMetricKey): WeekdayStat[] {
+  const buckets = WEEKDAYS.map(() => ({ sum: 0, n: 0 }));
+  for (const m of metrics) {
+    const v = m[key] as number | null;
+    if (v == null || !Number.isFinite(v)) continue;
+    // JS getDay(): 0=Sun..6=Sat → Mon-first index.
+    const idx = (parseISO(String(m.date)).getDay() + 6) % 7;
+    buckets[idx].sum += v;
+    buckets[idx].n += 1;
+  }
+  return WEEKDAYS.map((day, i) => ({
+    day,
+    value: buckets[i].n ? buckets[i].sum / buckets[i].n : null,
+    days: buckets[i].n,
+  }));
+}
+
+export interface EnergyPart {
+  key: "resting" | "active";
+  label: string;
+  color: string;
+  /** Mean kcal per day for this slice. */
+  avgKcal: number;
+  /** Share of the average day's total burn, 0–100. */
+  pct: number;
+}
+
+export interface EnergyComposition {
+  parts: EnergyPart[];
+  /** Mean total daily burn (resting + active) in kcal. */
+  totalKcal: number;
+  /** Whether any resting (basal) energy was recorded — false ⇒ active only. */
+  hasResting: boolean;
+}
+
+/**
+ * Split the average day's energy expenditure into resting (basal) and active
+ * (movement) kcal. Resting is the base your body burns just staying alive;
+ * active is everything the red Move ring counts on top. Parts are ordered
+ * resting-then-active so a gradient bar reads base-first.
+ */
+export function energyComposition(metrics: DailyMetric[]): EnergyComposition {
+  const avgActive = mean(metrics.map((d) => d.active_energy)) ?? 0;
+  const avgResting = mean(metrics.map((d) => d.basal_energy)) ?? 0;
+  const hasResting = metrics.some((d) => d.basal_energy != null);
+  const total = avgActive + avgResting;
+  const pct = (v: number) => (total > 0 ? (v / total) * 100 : 0);
+  const parts: EnergyPart[] = [
+    { key: "resting", label: "Resting", color: "var(--chart-4)", avgKcal: avgResting, pct: pct(avgResting) },
+    { key: "active", label: "Active", color: "var(--chart-3)", avgKcal: avgActive, pct: pct(avgActive) },
+  ];
+  return { parts, totalKcal: total, hasResting };
+}


### PR DESCRIPTION
Rebuilds the **Activity & Movement** page to match the depth of the recently-enriched Sleep dashboard.

## What's new

**Pure helpers** — `lib/activity.ts` (unit-tested, 6 cases):
- `energyComposition(metrics)` — splits the average day into resting (basal) vs active kcal, with a `hasResting` guard for ranges lacking basal data.
- `weekdayAverages(metrics, key)` — generic Mon-first weekday averaging of any numeric daily metric, using local-calendar dates per CLAUDE.md.

**Page** (`app/activity/page.tsx`), top to bottom:
1. **4 stat cards** with sparklines, 7-day deltas and sub-text (step totals, exercise ring-closure rate `X/Y days ≥30m`, cycling distance).
2. **Energy composition** card (gradient bar + descriptive Resting/Active breakdown — kcal/day, %, blurbs) beside a **Daily steps** chart with a bar/line/area toggle that fills the row height.
3. **Steps by day of week** + **Daily energy burn** (stacked resting+active area).
4. **Movement metrics** selector (`ConfigurableTrendChart`) over steps, distance, active energy, exercise minutes, flights — plus stand hours / cycling / walking-HR when present.
5. **Recent days** paginated table with a "steps vs best" intensity bar.

Every chart carries an info-icon tooltip.

## Testing
- `npm run typecheck` ✅
- `npm run lint` ✅ (no warnings)
- `npm run test` ✅ (93 passing)
- Browser-verified: no console errors; desktop and mobile layouts clean; energy data present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)